### PR TITLE
feat(admin): 管理后台全面多通道设置

### DIFF
--- a/app/admin/config/page.tsx
+++ b/app/admin/config/page.tsx
@@ -16,6 +16,7 @@ import {
   Bell,
   HardDrive,
   Plus,
+  Shield,
 } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Field, FieldDescription, FieldGroup, FieldLabel } from "@/components/ui/field";
@@ -235,6 +236,19 @@ export default function ConfigPage() {
 
   async function save() {
     if (!cfg) return;
+    // 管理面校验：已选通道则 chatId 必填
+    if (cfg.adminSurface && !cfg.adminSurface.chatId.trim()) {
+      toast.error("管理面已选通道但未填会话");
+      return;
+    }
+    // TG 管理面但 token 真正为空（非掩码）时仅警告，仍允许保存
+    if (
+      cfg.adminSurface?.channel === "tg" &&
+      !(cfg.telegramBotToken ?? "").includes("•") &&
+      !(cfg.telegramBotToken ?? "").trim()
+    ) {
+      toast.message("管理面为 TG 但未配置 Bot Token，通知可能发送失败");
+    }
     setBusy(true);
     // 保存前把输入框/批量区未点「添加」的内容一并写入，避免刷新后像「丢了」
     const tgIds = mergeTgChats(tgChatIds(cfg.enabledChats), tgChatDraft, tgChatBulk);
@@ -320,11 +334,28 @@ export default function ConfigPage() {
     setCfg({ ...cfg, enabledChats: withQqChats(cfg.enabledChats, Array.from(set)) });
   }
 
-  function setAdminQq(groupId: number) {
+  /** 管理面通道：none → null；qq/tg → { channel, chatId }（chatId 可暂空） */
+  function setAdminChannel(channel: "none" | "qq" | "tg") {
     if (!cfg) return;
+    if (channel === "none") {
+      setCfg({ ...cfg, adminSurface: null });
+      return;
+    }
+    const prev = cfg.adminSurface;
     setCfg({
       ...cfg,
-      adminSurface: groupId > 0 ? { channel: "qq", chatId: String(groupId) } : null,
+      adminSurface: {
+        channel,
+        chatId: prev?.channel === channel ? prev.chatId : "",
+      },
+    });
+  }
+
+  function setAdminChatId(chatId: string) {
+    if (!cfg || !cfg.adminSurface) return;
+    setCfg({
+      ...cfg,
+      adminSurface: { ...cfg.adminSurface, chatId },
     });
   }
 
@@ -350,6 +381,14 @@ export default function ConfigPage() {
     }
     return groups;
   };
+  /** TG 管理面：生效列表 + 当前 chatId 不在列表时注入占位 */
+  const adminTgOptions = (): string[] => {
+    const ids = cfg ? tgChatIds(cfg.enabledChats) : [];
+    const cur =
+      cfg?.adminSurface?.channel === "tg" ? cfg.adminSurface.chatId.trim() : "";
+    if (cur && !ids.includes(cur)) return [cur, ...ids];
+    return ids;
+  };
   const enabledQqIds = cfg ? qqChatIds(cfg.enabledChats) : [];
   const enabledTgIds = cfg ? tgChatIds(cfg.enabledChats) : [];
 
@@ -357,7 +396,7 @@ export default function ConfigPage() {
     <PageShell>
       <PageHeader
         title="配置"
-        description="修改后保存即生效。时间类配置按分钟显示。"
+        description="修改后保存即生效。通道连接与业务参数分栏。"
         actions={
           <Button onClick={save} disabled={busy || !cfg}>
             {busy ? <Spinner data-icon="inline-start" /> : <Save data-icon="inline-start" />}
@@ -369,21 +408,22 @@ export default function ConfigPage() {
       {!cfg && <Skeleton className="h-72 w-full" />}
 
       {cfg && (
-        <Tabs defaultValue="onebot">
+        <Tabs defaultValue="qq">
           <TabsList className="h-auto w-full flex-wrap justify-start">
-            <TabsTrigger value="onebot"><Cable data-icon="inline-start" /> OneBot</TabsTrigger>
-            <TabsTrigger value="telegram"><Send data-icon="inline-start" /> Telegram</TabsTrigger>
+            <TabsTrigger value="qq"><Cable data-icon="inline-start" /> QQ 通道</TabsTrigger>
+            <TabsTrigger value="tg"><Send data-icon="inline-start" /> TG 通道</TabsTrigger>
+            <TabsTrigger value="admin"><Shield data-icon="inline-start" /> 管理面</TabsTrigger>
             <TabsTrigger value="reply"><MessageSquareText data-icon="inline-start" /> 回复体验</TabsTrigger>
-            <TabsTrigger value="sdk"><Bot data-icon="inline-start" /> Claude SDK</TabsTrigger>
             <TabsTrigger value="session"><MessagesSquare data-icon="inline-start" /> 会话</TabsTrigger>
             <TabsTrigger value="reflect"><Brain data-icon="inline-start" /> 反思</TabsTrigger>
             <TabsTrigger value="proactive"><Zap data-icon="inline-start" /> 主动回复</TabsTrigger>
             <TabsTrigger value="notify"><Bell data-icon="inline-start" /> 通知</TabsTrigger>
+            <TabsTrigger value="sdk"><Bot data-icon="inline-start" /> Claude SDK</TabsTrigger>
             <TabsTrigger value="storage"><HardDrive data-icon="inline-start" /> 存储</TabsTrigger>
           </TabsList>
 
-          <TabsContent value="onebot">
-            <SectionCard title="OneBot 连接" description="OneBot 连接地址与群相关参数。">
+          <TabsContent value="qq">
+            <SectionCard title="QQ 通道" description="OneBot 连接地址与群相关参数。">
               <FieldGroup>
                 <Field>
                   <FieldLabel htmlFor="onebotWsUrl">WS 地址</FieldLabel>
@@ -397,36 +437,6 @@ export default function ConfigPage() {
                 <Field>
                   <FieldLabel htmlFor="botQQ">Bot QQ</FieldLabel>
                   <Input id="botQQ" inputMode="numeric" value={num("botQQ")} onChange={(e) => upd("botQQ", e.target.value)} />
-                </Field>
-                <Field>
-                  <FieldLabel htmlFor="handoffTimeoutMin">转人工超时(分钟)</FieldLabel>
-                  <Input id="handoffTimeoutMin" inputMode="numeric" value={num("handoffTimeoutMin")} onChange={(e) => upd("handoffTimeoutMin", e.target.value)} />
-                  <FieldDescription>转人工后无人处理超过此时长自动恢复自动答。默认 30 分钟。</FieldDescription>
-                </Field>
-                <Field>
-                  <FieldLabel htmlFor="adminSurface">管理群号</FieldLabel>
-                  {groups ? (
-                    <Select
-                      value={adminQq ? String(adminQq) : ""}
-                      onValueChange={(v) => setAdminQq(Number(v) || 0)}
-                    >
-                      <SelectTrigger id="adminSurface">
-                        <SelectValue placeholder="选择管理群" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {adminGroupOptions().map((g) => (
-                          <SelectItem key={g.groupId} value={String(g.groupId)}>
-                            {g.groupName} ({g.groupId})
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  ) : (
-                    <FieldDescription>
-                      {groupsLoading ? "正在获取群列表…" : "bot 未连接,无法获取群列表。请先填写连接并启动 bot。"}
-                    </FieldDescription>
-                  )}
-                  <FieldDescription>管理命令与转人工/反思通知落在此 QQ 群（一期仅 QQ 管理面）。</FieldDescription>
                 </Field>
                 <Field>
                   <FieldLabel htmlFor="enabledChatsQq">生效群</FieldLabel>
@@ -467,7 +477,7 @@ export default function ConfigPage() {
                         </div>
                       )}
                       <FieldDescription>
-                        仅这些群里 bot 才会回复。也可在「生效群」页一键开关。
+                        仅这些群里 bot 才会回复。也可在「生效会话」页一键开关。
                       </FieldDescription>
                     </>
                   ) : (
@@ -541,9 +551,9 @@ export default function ConfigPage() {
             </SectionCard>
           </TabsContent>
 
-          <TabsContent value="telegram" className="space-y-4">
+          <TabsContent value="tg" className="space-y-4">
             <SectionCard
-              title="Telegram Bot"
+              title="TG 通道"
               description="token 非空时注册 TG long poll；与 QQ 并行。同 token 仅允许单进程 poll（pm2 fork 单实例）。"
             >
               <FieldGroup>
@@ -666,10 +676,117 @@ export default function ConfigPage() {
                   <p className="text-foreground mb-1 font-medium">4. 触发方式</p>
                   <p>
                     群内 <code className="text-xs">@你的bot</code> 提问即可（username 大小写不敏感）。
-                    人工关键词不会抄送 QQ 管理群，用户侧引导 supportUrl。
+                    人工关键词不会抄送管理面，用户侧引导 supportUrl。
                   </p>
                 </div>
               </div>
+            </SectionCard>
+          </TabsContent>
+
+          <TabsContent value="admin">
+            <SectionCard
+              title="管理面"
+              description="转人工/反思/用量告警抄送与 !reset / !resume 落点。可与生效白名单无关。"
+            >
+              <FieldGroup>
+                <Field>
+                  <FieldLabel htmlFor="adminChannel">通道</FieldLabel>
+                  <Select
+                    value={cfg.adminSurface?.channel ?? "none"}
+                    onValueChange={(v) => setAdminChannel(v as "none" | "qq" | "tg")}
+                  >
+                    <SelectTrigger id="adminChannel">
+                      <SelectValue placeholder="选择管理面通道" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">无</SelectItem>
+                      <SelectItem value="qq">QQ</SelectItem>
+                      <SelectItem value="tg">Telegram</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FieldDescription>选择通知与管理命令落点通道；选「无」关闭管理面。</FieldDescription>
+                </Field>
+
+                {cfg.adminSurface?.channel === "qq" && (
+                  <Field>
+                    <FieldLabel htmlFor="adminSurfaceQq">管理群</FieldLabel>
+                    {groups ? (
+                      <Select
+                        value={adminQq ? String(adminQq) : ""}
+                        onValueChange={(v) => setAdminChatId(v)}
+                      >
+                        <SelectTrigger id="adminSurfaceQq">
+                          <SelectValue placeholder="选择管理群" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {adminGroupOptions().map((g) => (
+                            <SelectItem key={g.groupId} value={String(g.groupId)}>
+                              {g.groupName} ({g.groupId})
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    ) : (
+                      <FieldDescription>
+                        {groupsLoading
+                          ? "正在获取群列表…"
+                          : "bot 未连接,无法获取群列表。请先填写 QQ 通道连接并启动 bot。"}
+                      </FieldDescription>
+                    )}
+                  </Field>
+                )}
+
+                {cfg.adminSurface?.channel === "tg" && (
+                  <Field>
+                    <FieldLabel htmlFor="adminSurfaceTg">管理 Chat ID</FieldLabel>
+                    {adminTgOptions().length > 0 && (
+                      <Select
+                        value={
+                          cfg.adminSurface.chatId &&
+                          adminTgOptions().includes(cfg.adminSurface.chatId)
+                            ? cfg.adminSurface.chatId
+                            : ""
+                        }
+                        onValueChange={(v) => setAdminChatId(v)}
+                      >
+                        <SelectTrigger id="adminSurfaceTgSelect">
+                          <SelectValue placeholder="从生效 Chat 中选择" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {adminTgOptions().map((id) => (
+                            <SelectItem key={id} value={id}>
+                              {id}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    )}
+                    <Input
+                      id="adminSurfaceTg"
+                      className="mt-2 font-mono"
+                      value={cfg.adminSurface.chatId}
+                      placeholder="如 -1001234567890（可负号，字符串原样）"
+                      onChange={(e) => setAdminChatId(e.target.value)}
+                    />
+                    <FieldDescription>
+                      可从已生效 TG Chat 选择，或直接输入任意 chat id（不必在白名单内）。
+                    </FieldDescription>
+                  </Field>
+                )}
+
+                <Field>
+                  <FieldLabel htmlFor="handoffTimeoutMin">转人工超时(分钟)</FieldLabel>
+                  <Input
+                    id="handoffTimeoutMin"
+                    inputMode="numeric"
+                    value={num("handoffTimeoutMin")}
+                    onChange={(e) => upd("handoffTimeoutMin", e.target.value)}
+                  />
+                  <FieldDescription>
+                    转人工后无人处理超过此时长自动恢复自动答。默认 30 分钟。
+                  </FieldDescription>
+                </Field>
+              </FieldGroup>
             </SectionCard>
           </TabsContent>
 
@@ -697,7 +814,7 @@ export default function ConfigPage() {
                 <Field>
                   <FieldLabel htmlFor="usageBudgetUsd">日用量预算(USD)</FieldLabel>
                   <Input id="usageBudgetUsd" inputMode="decimal" value={num("usageBudgetUsd")} onChange={(e) => upd("usageBudgetUsd", e.target.value)} />
-                  <FieldDescription>超过后向管理群告警。0 = 不告警。</FieldDescription>
+                  <FieldDescription>超过后向管理面告警。0 = 不告警。</FieldDescription>
                 </Field>
               </FieldGroup>
             </SectionCard>
@@ -814,7 +931,7 @@ export default function ConfigPage() {
           </TabsContent>
 
           <TabsContent value="notify">
-            <SectionCard title="通知" description="向管理群推送的运行通知。">
+            <SectionCard title="通知" description="向管理面推送的运行通知。">
               <FieldGroup>
                 <Field orientation="horizontal">
                   <Checkbox
@@ -822,7 +939,7 @@ export default function ConfigPage() {
                     checked={cfg.reflectNotifyAdmin}
                     onCheckedChange={(v) => setCfg({ ...cfg, reflectNotifyAdmin: v === true })}
                   />
-                  <FieldLabel htmlFor="reflectNotifyAdmin">反思通知管理群</FieldLabel>
+                  <FieldLabel htmlFor="reflectNotifyAdmin">反思通知管理面</FieldLabel>
                 </Field>
               </FieldGroup>
             </SectionCard>

--- a/app/admin/config/page.tsx
+++ b/app/admin/config/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import {
   Save,
@@ -17,6 +17,8 @@ import {
   HardDrive,
   Plus,
   Shield,
+  TriangleAlert,
+  ChevronDown,
 } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Field, FieldDescription, FieldGroup, FieldLabel } from "@/components/ui/field";
@@ -33,6 +35,8 @@ import { Badge } from "@/components/ui/badge";
 import { PageShell } from "@/components/admin/page-shell";
 import { PageHeader } from "@/components/admin/page-header";
 import { SectionCard } from "@/components/admin/section-card";
+import { ChannelDot } from "@/components/channel-status-lights";
+import { useLive } from "@/components/live-provider";
 
 interface ChatRef {
   channel: "qq" | "tg" | "discord";
@@ -143,6 +147,7 @@ const hrToMs = (hr: string) => Math.round(Number(hr) * 3_600_000) || 0;
 const roleLabel = (role: "owner" | "admin") => (role === "owner" ? "群主" : "管理");
 
 export default function ConfigPage() {
+  const { status } = useLive();
   const [cfg, setCfg] = useState<Cfg | null>(null);
   const [busy, setBusy] = useState(false);
   const [groups, setGroups] = useState<{ groupId: number; groupName: string }[] | null>(null);
@@ -153,6 +158,8 @@ export default function ConfigPage() {
   const [tgChatDraft, setTgChatDraft] = useState("");
   /** 批量粘贴区（保存时合并，避免只贴未失焦就丢） */
   const [tgChatBulk, setTgChatBulk] = useState("");
+  /** chatId 字符串 → 显示名（/api/chats/names，含 TG 负 id） */
+  const [chatNames, setChatNames] = useState<Record<string, string>>({});
 
   useEffect(() => {
     fetch("/api/config").then((x) => x.json()).then((r) => {
@@ -180,6 +187,23 @@ export default function ConfigPage() {
       .then((r) => setGroups(r.ok ? r.data : null))
       .catch(() => setGroups(null))
       .finally(() => setGroupsLoading(false));
+  }, []);
+
+  // 多通道会话显示名（TG 负 id 以 Number 映射）
+  useEffect(() => {
+    fetch("/api/chats/names")
+      .then((x) => x.json())
+      .then((r) => {
+        if (!r.ok || !Array.isArray(r.data)) return;
+        const map: Record<string, string> = {};
+        for (const row of r.data as { groupId: number; groupName: string }[]) {
+          map[String(row.groupId)] = row.groupName;
+        }
+        setChatNames(map);
+      })
+      .catch(() => {
+        /* 名称仅展示用，失败静默 */
+      });
   }, []);
 
   // QQ 生效群变化后重拉跨群管理员名单(去重)。服务端 name-cache(含 role)命中时几乎瞬时。
@@ -399,6 +423,24 @@ export default function ConfigPage() {
   const enabledQqIds = cfg ? qqChatIds(cfg.enabledChats) : [];
   const enabledTgIds = cfg ? tgChatIds(cfg.enabledChats) : [];
 
+  const tgChannel = useMemo(
+    () => status?.channels?.find((c) => c.id === "tg"),
+    [status?.channels]
+  );
+  const tgTokenConfigured =
+    !!cfg &&
+    ((cfg.telegramBotToken ?? "").includes("•") ||
+      !!(cfg.telegramBotToken ?? "").trim());
+  const tgBypassWarn = !!(
+    tgChannel?.detail &&
+    /bypass-off|privacy/i.test(tgChannel.detail)
+  );
+  const tgChatTitle = (id: string) => {
+    const n = chatNames[id] ?? chatNames[String(Number(id))];
+    if (n && n !== id && n !== String(Number(id))) return n;
+    return null;
+  };
+
   return (
     <PageShell>
       <PageHeader
@@ -559,9 +601,20 @@ export default function ConfigPage() {
           </TabsContent>
 
           <TabsContent value="tg" className="space-y-4">
+            {/* 1. 连接 */}
             <SectionCard
-              title="TG 通道"
-              description="token 非空时注册 TG long poll；与 QQ 并行。同 token 仅允许单进程 poll（pm2 fork 单实例）。"
+              title="连接"
+              description="token 非空时注册 long poll，与 QQ 并行。同 token 仅允许单进程 poll（pm2 fork 单实例）。"
+              icon={Send}
+              action={
+                tgChannel ? (
+                  <ChannelDot ch={tgChannel} />
+                ) : !tgTokenConfigured ? (
+                  <span className="text-muted-foreground text-xs">未配置</span>
+                ) : (
+                  <span className="text-muted-foreground text-xs">状态同步中…</span>
+                )
+              }
             >
               <FieldGroup>
                 <Field>
@@ -577,13 +630,55 @@ export default function ConfigPage() {
                     来自 @BotFather。已保存密钥以掩码显示，留空或不改动则保留原值。token 为空则不启动 TG 通道。
                   </FieldDescription>
                 </Field>
+                {!tgTokenConfigured && (
+                  <p className="text-muted-foreground text-sm">
+                    未配置：填写 Token 并保存后启动 TG 通道。
+                  </p>
+                )}
+                {tgChannel?.lastError && (
+                  <div className="border-destructive/40 bg-destructive/5 text-destructive flex gap-2 rounded-md border px-3 py-2 text-sm">
+                    <TriangleAlert className="mt-0.5 size-4 shrink-0" />
+                    <div className="min-w-0">
+                      <p className="font-medium">通道异常</p>
+                      <p className="text-destructive/90 break-all text-xs">{tgChannel.lastError}</p>
+                    </div>
+                  </div>
+                )}
+                {tgBypassWarn && (
+                  <div className="border-amber-500/40 bg-amber-500/5 text-amber-900 dark:text-amber-200 flex gap-2 rounded-md border px-3 py-2 text-sm">
+                    <TriangleAlert className="mt-0.5 size-4 shrink-0" />
+                    <div className="min-w-0">
+                      <p className="font-medium">旁路已降级</p>
+                      <p className="text-xs opacity-90">
+                        运行状态 detail 提示 Privacy / bypass 关闭：反思与主动补位可能不可用。
+                        请在 @BotFather 关闭 Group Privacy Mode，并将 bot 重新拉进群。
+                        {tgChannel?.detail ? (
+                          <>
+                            {" "}
+                            <code className="text-[10px]">{tgChannel.detail}</code>
+                          </>
+                        ) : null}
+                      </p>
+                    </div>
+                  </div>
+                )}
+              </FieldGroup>
+            </SectionCard>
+
+            {/* 2. 生效会话 */}
+            <SectionCard
+              title="生效会话"
+              description="仅白名单内超级群/群会应答。也可在「生效会话」页开关与策略覆盖。"
+            >
+              <FieldGroup>
                 <Field>
-                  <FieldLabel htmlFor="tgChatDraft">生效 Chat ID</FieldLabel>
+                  <FieldLabel htmlFor="tgChatDraft">添加 Chat ID</FieldLabel>
                   <div className="flex flex-col gap-2 sm:flex-row">
                     <Input
                       id="tgChatDraft"
                       value={tgChatDraft}
                       placeholder="如 -1001234567890"
+                      className="font-mono text-sm"
                       onChange={(e) => setTgChatDraft(e.target.value)}
                       onKeyDown={(e) => {
                         if (e.key === "Enter") {
@@ -597,95 +692,148 @@ export default function ConfigPage() {
                       添加
                     </Button>
                   </div>
-                  {enabledTgIds.length > 0 ? (
-                    <div className="mt-2 flex flex-wrap gap-1">
-                      {enabledTgIds.map((id) => (
-                        <Badge
+                  <FieldDescription>
+                    id 按字符串保存（可负号）。Enter 或点添加写入列表；保存时也会合并未点添加的输入。
+                  </FieldDescription>
+                </Field>
+
+                {enabledTgIds.length > 0 ? (
+                  <ul className="divide-border divide-y rounded-md border">
+                    {enabledTgIds.map((id) => {
+                      const title = tgChatTitle(id);
+                      return (
+                        <li
                           key={id}
-                          variant="secondary"
-                          className="cursor-pointer gap-1 font-mono text-xs"
-                          onClick={() => removeTgChat(id)}
+                          className="flex items-center justify-between gap-2 px-3 py-2 text-sm"
                         >
-                          {id}
-                          <X className="size-3" />
-                        </Badge>
-                      ))}
-                    </div>
-                  ) : (
+                          <div className="min-w-0 flex flex-col">
+                            {title ? (
+                              <span className="truncate font-medium">{title}</span>
+                            ) : null}
+                            <span className="text-muted-foreground font-mono text-xs">{id}</span>
+                          </div>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="shrink-0"
+                            onClick={() => removeTgChat(id)}
+                            aria-label={`移除 ${id}`}
+                          >
+                            <X className="size-4" />
+                          </Button>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                ) : (
+                  <p className="text-muted-foreground text-sm">
+                    尚未添加会话。添加后 bot 才会在对应群内 @ 应答。
+                  </p>
+                )}
+
+                <details className="group rounded-md border">
+                  <summary className="text-muted-foreground hover:text-foreground flex cursor-pointer list-none items-center gap-1.5 px-3 py-2 text-sm select-none [&::-webkit-details-marker]:hidden">
+                    <ChevronDown className="size-3.5 shrink-0 transition-transform group-open:rotate-180" />
+                    高级：批量粘贴 Chat ID
+                  </summary>
+                  <div className="border-t px-3 py-3">
+                    <Textarea
+                      id="tgChatBulk"
+                      value={tgChatBulk}
+                      placeholder={"每行一个，或用逗号分隔\n-1001234567890\n-1009876543210"}
+                      rows={3}
+                      className="font-mono text-xs"
+                      onChange={(e) => setTgChatBulk(e.target.value)}
+                      onBlur={() => commitTgBulk()}
+                    />
                     <p className="text-muted-foreground mt-2 text-xs">
-                      尚未添加任何 chat。仅输入框有字、下方没有徽章时，刷新会丢——请点「添加」或直接「保存并生效」。
+                      失焦或「保存并生效」时合并进上方列表（去重）。
                     </p>
-                  )}
-                  <FieldDescription>
-                    仅这些超级群/群里 bot 才会应答。id 按<strong>字符串</strong>保存（可负号）。
-                    点徽章可移除。保存时会自动带上输入框/批量区未点添加的内容。
-                  </FieldDescription>
-                </Field>
-                <Field>
-                  <FieldLabel htmlFor="tgChatBulk">批量粘贴 Chat ID</FieldLabel>
-                  <Textarea
-                    id="tgChatBulk"
-                    value={tgChatBulk}
-                    placeholder={"每行一个，或用逗号分隔\n-1001234567890\n-1009876543210"}
-                    rows={3}
-                    className="font-mono text-xs"
-                    onChange={(e) => setTgChatBulk(e.target.value)}
-                    onBlur={() => commitTgBulk()}
-                  />
-                  <FieldDescription>
-                    失焦或点「保存并生效」时合并进上方列表（去重）。合并成功后上方应出现徽章。
-                  </FieldDescription>
-                </Field>
+                  </div>
+                </details>
               </FieldGroup>
             </SectionCard>
 
+            {/* 3. 部署与说明 */}
             <SectionCard
-              title="部署清单与帮助"
-              description="旁路（反思 / 主动补位）依赖全量群消息与管理员角色；主链路 @ 问答在 Privacy 开启时仍可用。"
+              title="部署与说明"
+              description="旁路（反思 / 主动补位）依赖全量群消息与管理员角色；@ 问答在 Privacy 开启时仍可用。"
             >
-              <div className="text-muted-foreground space-y-3 text-sm leading-relaxed">
-                <div>
-                  <p className="text-foreground mb-1 font-medium">1. 关闭 Group Privacy Mode（必做）</p>
-                  <ol className="list-decimal space-y-1 pl-5">
-                    <li>打开 @BotFather → 你的 bot → Bot Settings → Group Privacy → <strong>Turn off</strong>。</li>
-                    <li>
-                      开启时 bot 只能收到 @ 自己、回复 bot 与命令，<strong>收不到普通群聊</strong>；
-                      反思 / 补位原料不足，运行时会对该 chat 降级关闭旁路（状态 detail 见{" "}
-                      <code className="text-xs">bypass-off:…:privacy-mode?</code>）。
-                    </li>
-                    <li>关闭后建议将 bot 踢出再重新拉进目标群，确保权限生效。</li>
-                  </ol>
-                </div>
-                <div>
-                  <p className="text-foreground mb-1 font-medium">2. 如何取得 Chat ID</p>
-                  <ul className="list-disc space-y-1 pl-5">
-                    <li>
-                      把 bot 拉进超级群后，在群里发一条消息，再请求{" "}
-                      <code className="text-xs">getUpdates</code>（或临时看运行日志）里的{" "}
-                      <code className="text-xs">message.chat.id</code>。
-                    </li>
-                    <li>
-                      也可用第三方查询 bot（如 @userinfobot / @getidsbot）转发群消息查看 id。
-                    </li>
-                    <li>
-                      超级群 id 通常形如 <code className="text-xs">-100…</code>，整串复制，不要丢负号或前缀。
-                    </li>
-                  </ul>
-                </div>
-                <div>
-                  <p className="text-foreground mb-1 font-medium">3. 单实例 long poll</p>
-                  <p>
-                    同一 bot token 同一时刻只能有一个 <code className="text-xs">getUpdates</code> 消费者。
-                    多实例（pm2 cluster / 多进程）会 409 Conflict，状态灯显示 lastError，QQ 不受影响。
-                  </p>
-                </div>
-                <div>
-                  <p className="text-foreground mb-1 font-medium">4. 触发方式</p>
-                  <p>
-                    群内 <code className="text-xs">@你的bot</code> 提问即可（username 大小写不敏感）。
-                    人工关键词不会抄送管理面，用户侧引导 supportUrl。
-                  </p>
-                </div>
+              <div className="space-y-2">
+                <details className="group rounded-md border" open>
+                  <summary className="hover:bg-muted/40 flex cursor-pointer list-none items-center gap-1.5 px-3 py-2 text-sm font-medium select-none [&::-webkit-details-marker]:hidden">
+                    <ChevronDown className="size-3.5 shrink-0 transition-transform group-open:rotate-180" />
+                    关闭 Group Privacy Mode（必做）
+                  </summary>
+                  <div className="text-muted-foreground border-t px-3 py-3 text-sm leading-relaxed">
+                    <ol className="list-decimal space-y-1 pl-5">
+                      <li>
+                        打开 @BotFather → 你的 bot → Bot Settings → Group Privacy →{" "}
+                        <strong className="text-foreground">Turn off</strong>。
+                      </li>
+                      <li>
+                        开启时 bot 只能收到 @ 自己、回复 bot 与命令，
+                        <strong className="text-foreground">收不到普通群聊</strong>
+                        ；反思 / 补位原料不足，运行时会对该 chat 降级关闭旁路（detail 见{" "}
+                        <code className="text-xs">bypass-off:…:privacy-mode?</code>）。
+                      </li>
+                      <li>关闭后建议将 bot 踢出再重新拉进目标群，确保权限生效。</li>
+                    </ol>
+                  </div>
+                </details>
+
+                <details className="group rounded-md border">
+                  <summary className="hover:bg-muted/40 flex cursor-pointer list-none items-center gap-1.5 px-3 py-2 text-sm font-medium select-none [&::-webkit-details-marker]:hidden">
+                    <ChevronDown className="size-3.5 shrink-0 transition-transform group-open:rotate-180" />
+                    如何取得 Chat ID
+                  </summary>
+                  <div className="text-muted-foreground border-t px-3 py-3 text-sm leading-relaxed">
+                    <ul className="list-disc space-y-1 pl-5">
+                      <li>
+                        把 bot 拉进超级群后，在群里发一条消息，再请求{" "}
+                        <code className="text-xs">getUpdates</code>（或看运行日志）里的{" "}
+                        <code className="text-xs">message.chat.id</code>。
+                      </li>
+                      <li>
+                        也可用第三方查询 bot（如 @userinfobot / @getidsbot）转发群消息查看 id。
+                      </li>
+                      <li>
+                        超级群 id 通常形如 <code className="text-xs">-100…</code>
+                        ，整串复制，不要丢负号或前缀。
+                      </li>
+                    </ul>
+                  </div>
+                </details>
+
+                <details className="group rounded-md border">
+                  <summary className="hover:bg-muted/40 flex cursor-pointer list-none items-center gap-1.5 px-3 py-2 text-sm font-medium select-none [&::-webkit-details-marker]:hidden">
+                    <ChevronDown className="size-3.5 shrink-0 transition-transform group-open:rotate-180" />
+                    单实例 long poll
+                  </summary>
+                  <div className="text-muted-foreground border-t px-3 py-3 text-sm leading-relaxed">
+                    <p>
+                      同一 bot token 同一时刻只能有一个{" "}
+                      <code className="text-xs">getUpdates</code> 消费者。多实例（pm2 cluster /
+                      多进程）会 409 Conflict，状态灯显示 lastError，QQ 不受影响。
+                    </p>
+                  </div>
+                </details>
+
+                <details className="group rounded-md border">
+                  <summary className="hover:bg-muted/40 flex cursor-pointer list-none items-center gap-1.5 px-3 py-2 text-sm font-medium select-none [&::-webkit-details-marker]:hidden">
+                    <ChevronDown className="size-3.5 shrink-0 transition-transform group-open:rotate-180" />
+                    触发与转人工
+                  </summary>
+                  <div className="text-muted-foreground border-t px-3 py-3 text-sm leading-relaxed">
+                    <p>
+                      群内 <code className="text-xs">@你的bot</code> 提问即可（username
+                      大小写不敏感）。用户发「人工」时：通知抄送到配置页的
+                      <strong className="text-foreground">管理面</strong>
+                      （可 QQ 或 TG）；用户侧仍可附带 supportUrl。
+                    </p>
+                  </div>
+                </details>
               </div>
             </SectionCard>
           </TabsContent>

--- a/app/admin/config/page.tsx
+++ b/app/admin/config/page.tsx
@@ -17,7 +17,6 @@ import {
   HardDrive,
   Plus,
   Shield,
-  TriangleAlert,
 } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Field, FieldDescription, FieldGroup, FieldLabel } from "@/components/ui/field";
@@ -587,12 +586,10 @@ export default function ConfigPage() {
             </SectionCard>
           </TabsContent>
 
-          <TabsContent value="tg" className="space-y-4">
-            {/* 1. 连接 */}
+          <TabsContent value="tg">
             <SectionCard
-              title="连接"
-              description="token 非空时注册 long poll，与 QQ 并行。同 token 仅允许单进程 poll（pm2 fork 单实例）。"
-              icon={Send}
+              title="TG 通道"
+              description="Telegram Bot Token 与群相关参数。"
               action={
                 tgChannel ? (
                   <ChannelDot ch={tgChannel} />
@@ -609,62 +606,37 @@ export default function ConfigPage() {
                   <Input
                     id="telegramBotToken"
                     value={cfg.telegramBotToken ?? ""}
-                    placeholder="留空不修改；清空需先保存再在环境/库中清"
+                    placeholder="留空不修改"
                     onChange={(e) => setCfg({ ...cfg, telegramBotToken: e.target.value })}
                     autoComplete="off"
                   />
                   <FieldDescription>
-                    来自 @BotFather。已保存密钥以掩码显示，留空或不改动则保留原值。token 为空则不启动 TG 通道。
+                    来自 @BotFather。已保存的密钥以掩码显示,留空或不改动则保留原值。token 为空则不启动 TG 通道。
                   </FieldDescription>
+                  {tgChannel?.lastError ? (
+                    <p className="text-destructive mt-1 text-sm">
+                      通道异常: {tgChannel.lastError}
+                    </p>
+                  ) : null}
+                  {tgBypassWarn ? (
+                    <p className="text-amber-800 dark:text-amber-200 mt-1 text-sm">
+                      旁路已降级(Privacy / bypass 关闭):反思与主动补位可能不可用。请在 @BotFather
+                      关闭 Group Privacy Mode 并重新拉 bot 进群。
+                      {tgChannel?.detail ? (
+                        <span className="text-muted-foreground ml-1 font-mono text-xs">
+                          {tgChannel.detail}
+                        </span>
+                      ) : null}
+                    </p>
+                  ) : null}
                 </Field>
-                {!tgTokenConfigured && (
-                  <p className="text-muted-foreground text-sm">
-                    未配置：填写 Token 并保存后启动 TG 通道。
-                  </p>
-                )}
-                {tgChannel?.lastError && (
-                  <div className="border-destructive/40 bg-destructive/5 text-destructive flex gap-2 rounded-md border px-3 py-2 text-sm">
-                    <TriangleAlert className="mt-0.5 size-4 shrink-0" />
-                    <div className="min-w-0">
-                      <p className="font-medium">通道异常</p>
-                      <p className="text-destructive/90 break-all text-xs">{tgChannel.lastError}</p>
-                    </div>
-                  </div>
-                )}
-                {tgBypassWarn && (
-                  <div className="border-amber-500/40 bg-amber-500/5 text-amber-900 dark:text-amber-200 flex gap-2 rounded-md border px-3 py-2 text-sm">
-                    <TriangleAlert className="mt-0.5 size-4 shrink-0" />
-                    <div className="min-w-0">
-                      <p className="font-medium">旁路已降级</p>
-                      <p className="text-xs opacity-90">
-                        运行状态 detail 提示 Privacy / bypass 关闭：反思与主动补位可能不可用。
-                        请在 @BotFather 关闭 Group Privacy Mode，并将 bot 重新拉进群。
-                        {tgChannel?.detail ? (
-                          <>
-                            {" "}
-                            <code className="text-[10px]">{tgChannel.detail}</code>
-                          </>
-                        ) : null}
-                      </p>
-                    </div>
-                  </div>
-                )}
-              </FieldGroup>
-            </SectionCard>
-
-            {/* 2. 生效会话 */}
-            <SectionCard
-              title="生效会话"
-              description="仅白名单内超级群/群会应答。也可在「生效会话」页开关与策略覆盖。"
-            >
-              <FieldGroup>
                 <Field>
-                  <FieldLabel htmlFor="tgChatDraft">添加 Chat ID</FieldLabel>
+                  <FieldLabel htmlFor="enabledChatsTg">生效群</FieldLabel>
                   <div className="flex flex-col gap-2 sm:flex-row">
                     <Input
-                      id="tgChatDraft"
+                      id="enabledChatsTg"
                       value={tgChatDraft}
-                      placeholder="如 -1001234567890"
+                      placeholder="Chat ID,如 -1001234567890"
                       className="font-mono text-sm"
                       onChange={(e) => setTgChatDraft(e.target.value)}
                       onKeyDown={(e) => {
@@ -679,45 +651,28 @@ export default function ConfigPage() {
                       添加
                     </Button>
                   </div>
+                  {enabledTgIds.length > 0 && (
+                    <div className="mt-2 flex flex-wrap gap-1">
+                      {enabledTgIds.map((id) => {
+                        const title = tgChatTitle(id);
+                        return (
+                          <Badge
+                            key={id}
+                            variant="secondary"
+                            className="cursor-pointer gap-1"
+                            onClick={() => removeTgChat(id)}
+                          >
+                            {title ? `${title} (${id})` : id}
+                            <X className="size-3" />
+                          </Badge>
+                        );
+                      })}
+                    </div>
+                  )}
                   <FieldDescription>
-                    id 按字符串保存（可负号）。Enter 或点添加写入列表；保存时也会合并未点添加的输入。
+                    仅这些群里 bot 才会回复。id 按字符串保存(可负号);Enter 或点添加写入,保存时也会合并未点添加的输入。也可在「生效会话」页一键开关。
                   </FieldDescription>
                 </Field>
-
-                {enabledTgIds.length > 0 ? (
-                  <ul className="divide-border divide-y rounded-md border">
-                    {enabledTgIds.map((id) => {
-                      const title = tgChatTitle(id);
-                      return (
-                        <li
-                          key={id}
-                          className="flex items-center justify-between gap-2 px-3 py-2 text-sm"
-                        >
-                          <div className="min-w-0 flex flex-col">
-                            {title ? (
-                              <span className="truncate font-medium">{title}</span>
-                            ) : null}
-                            <span className="text-muted-foreground font-mono text-xs">{id}</span>
-                          </div>
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            className="shrink-0"
-                            onClick={() => removeTgChat(id)}
-                            aria-label={`移除 ${id}`}
-                          >
-                            <X className="size-4" />
-                          </Button>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                ) : (
-                  <p className="text-muted-foreground text-sm">
-                    尚未添加会话。添加后 bot 才会在对应群内 @ 应答。
-                  </p>
-                )}
               </FieldGroup>
             </SectionCard>
           </TabsContent>

--- a/app/admin/config/page.tsx
+++ b/app/admin/config/page.tsx
@@ -18,12 +18,10 @@ import {
   Plus,
   Shield,
   TriangleAlert,
-  ChevronDown,
 } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Field, FieldDescription, FieldGroup, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
@@ -156,8 +154,6 @@ export default function ConfigPage() {
   const [adminsLoading, setAdminsLoading] = useState(false);
   /** 待加入的 TG chat id 草稿（点添加 / 保存时合并） */
   const [tgChatDraft, setTgChatDraft] = useState("");
-  /** 批量粘贴区（保存时合并，避免只贴未失焦就丢） */
-  const [tgChatBulk, setTgChatBulk] = useState("");
   /** chatId 字符串 → 显示名（/api/chats/names，含 TG 负 id） */
   const [chatNames, setChatNames] = useState<Record<string, string>>({});
 
@@ -274,8 +270,8 @@ export default function ConfigPage() {
       toast.message("管理面为 TG 但未配置 Bot Token，通知可能发送失败");
     }
     setBusy(true);
-    // 保存前把输入框/批量区未点「添加」的内容一并写入，避免刷新后像「丢了」
-    const tgIds = mergeTgChats(tgChatIds(cfg.enabledChats), tgChatDraft, tgChatBulk);
+    // 保存前把输入框未点「添加」的内容一并写入
+    const tgIds = mergeTgChats(tgChatIds(cfg.enabledChats), tgChatDraft);
     const enabledChats = withTgChats(cfg.enabledChats, tgIds);
     const payload: Partial<Cfg> = {
       ...cfg,
@@ -313,7 +309,6 @@ export default function ConfigPage() {
           adminSurface: data.adminSurface ?? null,
         });
         setTgChatDraft("");
-        setTgChatBulk("");
         if (savedTg.length === 0 && !cfg.telegramBotToken) {
           toast.success("配置已保存并生效");
         } else if (savedTg.length === 0) {
@@ -345,14 +340,6 @@ export default function ConfigPage() {
     if (!cfg) return;
     const next = tgChatIds(cfg.enabledChats).filter((c) => c !== id);
     setCfg({ ...cfg, enabledChats: withTgChats(cfg.enabledChats, next) });
-  }
-
-  /** 把批量框内容合并进列表并清空批量框 */
-  function commitTgBulk() {
-    if (!cfg || !tgChatBulk.trim()) return;
-    const next = mergeTgChats(tgChatIds(cfg.enabledChats), tgChatBulk);
-    setCfg({ ...cfg, enabledChats: withTgChats(cfg.enabledChats, next) });
-    setTgChatBulk("");
   }
 
   const num = (k: keyof Cfg) => (cfg ? String(cfg[k] ?? "") : "");
@@ -731,110 +718,7 @@ export default function ConfigPage() {
                     尚未添加会话。添加后 bot 才会在对应群内 @ 应答。
                   </p>
                 )}
-
-                <details className="group rounded-md border">
-                  <summary className="text-muted-foreground hover:text-foreground flex cursor-pointer list-none items-center gap-1.5 px-3 py-2 text-sm select-none [&::-webkit-details-marker]:hidden">
-                    <ChevronDown className="size-3.5 shrink-0 transition-transform group-open:rotate-180" />
-                    高级：批量粘贴 Chat ID
-                  </summary>
-                  <div className="border-t px-3 py-3">
-                    <Textarea
-                      id="tgChatBulk"
-                      value={tgChatBulk}
-                      placeholder={"每行一个，或用逗号分隔\n-1001234567890\n-1009876543210"}
-                      rows={3}
-                      className="font-mono text-xs"
-                      onChange={(e) => setTgChatBulk(e.target.value)}
-                      onBlur={() => commitTgBulk()}
-                    />
-                    <p className="text-muted-foreground mt-2 text-xs">
-                      失焦或「保存并生效」时合并进上方列表（去重）。
-                    </p>
-                  </div>
-                </details>
               </FieldGroup>
-            </SectionCard>
-
-            {/* 3. 部署与说明 */}
-            <SectionCard
-              title="部署与说明"
-              description="旁路（反思 / 主动补位）依赖全量群消息与管理员角色；@ 问答在 Privacy 开启时仍可用。"
-            >
-              <div className="space-y-2">
-                <details className="group rounded-md border" open>
-                  <summary className="hover:bg-muted/40 flex cursor-pointer list-none items-center gap-1.5 px-3 py-2 text-sm font-medium select-none [&::-webkit-details-marker]:hidden">
-                    <ChevronDown className="size-3.5 shrink-0 transition-transform group-open:rotate-180" />
-                    关闭 Group Privacy Mode（必做）
-                  </summary>
-                  <div className="text-muted-foreground border-t px-3 py-3 text-sm leading-relaxed">
-                    <ol className="list-decimal space-y-1 pl-5">
-                      <li>
-                        打开 @BotFather → 你的 bot → Bot Settings → Group Privacy →{" "}
-                        <strong className="text-foreground">Turn off</strong>。
-                      </li>
-                      <li>
-                        开启时 bot 只能收到 @ 自己、回复 bot 与命令，
-                        <strong className="text-foreground">收不到普通群聊</strong>
-                        ；反思 / 补位原料不足，运行时会对该 chat 降级关闭旁路（detail 见{" "}
-                        <code className="text-xs">bypass-off:…:privacy-mode?</code>）。
-                      </li>
-                      <li>关闭后建议将 bot 踢出再重新拉进目标群，确保权限生效。</li>
-                    </ol>
-                  </div>
-                </details>
-
-                <details className="group rounded-md border">
-                  <summary className="hover:bg-muted/40 flex cursor-pointer list-none items-center gap-1.5 px-3 py-2 text-sm font-medium select-none [&::-webkit-details-marker]:hidden">
-                    <ChevronDown className="size-3.5 shrink-0 transition-transform group-open:rotate-180" />
-                    如何取得 Chat ID
-                  </summary>
-                  <div className="text-muted-foreground border-t px-3 py-3 text-sm leading-relaxed">
-                    <ul className="list-disc space-y-1 pl-5">
-                      <li>
-                        把 bot 拉进超级群后，在群里发一条消息，再请求{" "}
-                        <code className="text-xs">getUpdates</code>（或看运行日志）里的{" "}
-                        <code className="text-xs">message.chat.id</code>。
-                      </li>
-                      <li>
-                        也可用第三方查询 bot（如 @userinfobot / @getidsbot）转发群消息查看 id。
-                      </li>
-                      <li>
-                        超级群 id 通常形如 <code className="text-xs">-100…</code>
-                        ，整串复制，不要丢负号或前缀。
-                      </li>
-                    </ul>
-                  </div>
-                </details>
-
-                <details className="group rounded-md border">
-                  <summary className="hover:bg-muted/40 flex cursor-pointer list-none items-center gap-1.5 px-3 py-2 text-sm font-medium select-none [&::-webkit-details-marker]:hidden">
-                    <ChevronDown className="size-3.5 shrink-0 transition-transform group-open:rotate-180" />
-                    单实例 long poll
-                  </summary>
-                  <div className="text-muted-foreground border-t px-3 py-3 text-sm leading-relaxed">
-                    <p>
-                      同一 bot token 同一时刻只能有一个{" "}
-                      <code className="text-xs">getUpdates</code> 消费者。多实例（pm2 cluster /
-                      多进程）会 409 Conflict，状态灯显示 lastError，QQ 不受影响。
-                    </p>
-                  </div>
-                </details>
-
-                <details className="group rounded-md border">
-                  <summary className="hover:bg-muted/40 flex cursor-pointer list-none items-center gap-1.5 px-3 py-2 text-sm font-medium select-none [&::-webkit-details-marker]:hidden">
-                    <ChevronDown className="size-3.5 shrink-0 transition-transform group-open:rotate-180" />
-                    触发与转人工
-                  </summary>
-                  <div className="text-muted-foreground border-t px-3 py-3 text-sm leading-relaxed">
-                    <p>
-                      群内 <code className="text-xs">@你的bot</code> 提问即可（username
-                      大小写不敏感）。用户发「人工」时：通知抄送到配置页的
-                      <strong className="text-foreground">管理面</strong>
-                      （可 QQ 或 TG）；用户侧仍可附带 supportUrl。
-                    </p>
-                  </div>
-                </details>
-              </div>
             </SectionCard>
           </TabsContent>
 

--- a/app/admin/config/page.tsx
+++ b/app/admin/config/page.tsx
@@ -256,6 +256,13 @@ export default function ConfigPage() {
     const payload: Partial<Cfg> = {
       ...cfg,
       enabledChats,
+      // chatId 去空白，避免 isAdminSurface 精确匹配失败
+      adminSurface: cfg.adminSurface
+        ? {
+            channel: cfg.adminSurface.channel,
+            chatId: cfg.adminSurface.chatId.trim(),
+          }
+        : null,
     };
     if (typeof payload.onebotAccessToken === "string" && payload.onebotAccessToken.includes("•")) {
       delete payload.onebotAccessToken;

--- a/app/admin/groups/page.tsx
+++ b/app/admin/groups/page.tsx
@@ -106,6 +106,20 @@ function channelLabel(c: ChannelId): string {
   return c;
 }
 
+/**
+ * 策略写 payload：新键 policyKey；QQ 同时清掉历史裸群号键，避免 getGroupPolicy 回退读到旧覆盖。
+ */
+function policyWritePayload(
+  row: Pick<Row, "channel" | "chatId" | "policyKey">,
+  policy: GroupPolicy | null
+): Record<string, GroupPolicy | null> {
+  const out: Record<string, GroupPolicy | null> = { [row.policyKey]: policy };
+  if (row.channel === "qq" && row.chatId) {
+    out[row.chatId] = null;
+  }
+  return out;
+}
+
 export default function GroupsPage() {
   const { data, error, loading, refresh } = usePolling<ActivityData>("/api/groups/activity");
   const { name } = useGroupNames();
@@ -197,16 +211,15 @@ export default function GroupsPage() {
       const nh = triToBool(handoffTri);
       if (nh !== undefined) policy.notifyAdminOnHandoff = nh;
 
-      const key = editing.policyKey;
-      const payload =
+      const groupPolicies =
         Object.keys(policy).length === 0
-          ? { groupPolicies: { [key]: null } }
-          : { groupPolicies: { [key]: policy } };
+          ? policyWritePayload(editing, null)
+          : policyWritePayload(editing, policy);
 
       const r = await fetch("/api/config", {
         method: "PUT",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify(payload),
+        body: JSON.stringify({ groupPolicies }),
       }).then((x) => x.json());
       if (r.ok) {
         toast.success(
@@ -230,7 +243,9 @@ export default function GroupsPage() {
       const r = await fetch("/api/config", {
         method: "PUT",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ groupPolicies: { [row.policyKey]: null } }),
+        body: JSON.stringify({
+          groupPolicies: policyWritePayload(row, null),
+        }),
       }).then((x) => x.json());
       if (r.ok) {
         toast.success(
@@ -452,7 +467,7 @@ export default function GroupsPage() {
               </Field>
 
               <Field>
-                <FieldLabel>转人工时通知管理群</FieldLabel>
+                <FieldLabel>转人工时通知管理面</FieldLabel>
                 <Select value={handoffTri} onValueChange={(v) => setHandoffTri(v as Tri)}>
                   <SelectTrigger>
                     <SelectValue />
@@ -464,7 +479,7 @@ export default function GroupsPage() {
                   </SelectContent>
                 </Select>
                 <FieldDescription>
-                  仅控制转人工时是否向管理群发消息;会话仍会进入人工接待。
+                  仅控制转人工时是否向管理面发消息;会话仍会进入人工接待。
                 </FieldDescription>
               </Field>
             </FieldGroup>

--- a/app/admin/groups/page.tsx
+++ b/app/admin/groups/page.tsx
@@ -37,6 +37,8 @@ import { useGroupNames } from "@/lib/group-name";
 
 type Tri = "inherit" | "on" | "off";
 
+type ChannelId = "qq" | "tg" | "discord";
+
 interface GroupPolicy {
   proactiveEnabled?: boolean;
   proactiveSilenceMs?: number;
@@ -44,6 +46,9 @@ interface GroupPolicy {
 }
 
 interface Row {
+  channel: ChannelId;
+  chatId: string;
+  /** 兼容旧字段；勿作主键 */
   groupId: number;
   enabled: boolean;
   messageCount: number;
@@ -52,6 +57,7 @@ interface Row {
   sedimentedCount: number;
   policy: GroupPolicy;
   hasOverride: boolean;
+  policyKey: string;
   effective: {
     proactiveEnabled: boolean;
     proactiveSilenceMs: number;
@@ -82,10 +88,28 @@ function triToBool(t: Tri): boolean | undefined {
   return t === "on";
 }
 
+function rowLabel(
+  r: Pick<Row, "channel" | "chatId" | "groupId">,
+  nameFn: (id: number) => string
+): string {
+  if (r.channel === "qq" && r.groupId > 0) return nameFn(r.groupId);
+  if (r.channel === "tg" && r.groupId !== 0) {
+    const n = nameFn(r.groupId);
+    if (n && n !== String(r.groupId)) return n;
+  }
+  return r.chatId;
+}
+
+function channelLabel(c: ChannelId): string {
+  if (c === "qq") return "QQ";
+  if (c === "tg") return "TG";
+  return c;
+}
+
 export default function GroupsPage() {
   const { data, error, loading, refresh } = usePolling<ActivityData>("/api/groups/activity");
   const { name } = useGroupNames();
-  const [busyId, setBusyId] = useState<number | null>(null);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
   const [editing, setEditing] = useState<Row | null>(null);
   const [savingPolicy, setSavingPolicy] = useState(false);
 
@@ -113,8 +137,8 @@ export default function GroupsPage() {
     setHandoffTri(triFrom(r.policy.notifyAdminOnHandoff));
   }
 
-  async function toggle(groupId: number, enable: boolean) {
-    setBusyId(groupId);
+  async function toggle(row: Row, enable: boolean) {
+    setBusyKey(row.policyKey);
     try {
       const cur = await fetch("/api/config").then((x) => x.json());
       if (!cur.ok) {
@@ -125,9 +149,11 @@ export default function GroupsPage() {
       const chats: ChatRef[] = Array.isArray(cur.data.enabledChats)
         ? [...cur.data.enabledChats]
         : [];
-      const others = chats.filter((c) => !(c.channel === "qq" && c.chatId === String(groupId)));
+      const others = chats.filter(
+        (c) => !(c.channel === row.channel && c.chatId === row.chatId)
+      );
       const next: ChatRef[] = enable
-        ? [...others, { channel: "qq", chatId: String(groupId) }]
+        ? [...others, { channel: row.channel, chatId: row.chatId }]
         : others;
       const r = await fetch("/api/config", {
         method: "PUT",
@@ -135,7 +161,8 @@ export default function GroupsPage() {
         body: JSON.stringify({ enabledChats: next }),
       }).then((x) => x.json());
       if (r.ok) {
-        toast.success(enable ? `已生效: ${name(groupId)}` : `已关闭: ${name(groupId)}`);
+        const label = `${channelLabel(row.channel)} · ${rowLabel(row, name)}`;
+        toast.success(enable ? `已生效: ${label}` : `已关闭: ${label}`);
         if (enable) {
           toast.message("用法提示", {
             description: "群内问 bot 请 @机器人;重置发「重置」;转人工发「人工」。",
@@ -148,7 +175,7 @@ export default function GroupsPage() {
     } catch (e) {
       toast.error(e instanceof Error ? e.message : String(e));
     } finally {
-      setBusyId(null);
+      setBusyKey(null);
     }
   }
 
@@ -170,11 +197,11 @@ export default function GroupsPage() {
       const nh = triToBool(handoffTri);
       if (nh !== undefined) policy.notifyAdminOnHandoff = nh;
 
-      // 无任何覆盖 → 传 null 清除
+      const key = editing.policyKey;
       const payload =
         Object.keys(policy).length === 0
-          ? { groupPolicies: { [String(editing.groupId)]: null } }
-          : { groupPolicies: { [String(editing.groupId)]: policy } };
+          ? { groupPolicies: { [key]: null } }
+          : { groupPolicies: { [key]: policy } };
 
       const r = await fetch("/api/config", {
         method: "PUT",
@@ -182,7 +209,9 @@ export default function GroupsPage() {
         body: JSON.stringify(payload),
       }).then((x) => x.json());
       if (r.ok) {
-        toast.success(`已保存 ${name(editing.groupId)} 的策略`);
+        toast.success(
+          `已保存 ${channelLabel(editing.channel)} · ${rowLabel(editing, name)} 的策略`
+        );
         setEditing(null);
         await refresh();
       } else {
@@ -195,31 +224,33 @@ export default function GroupsPage() {
     }
   }
 
-  async function clearPolicy(groupId: number) {
-    setBusyId(groupId);
+  async function clearPolicy(row: Row) {
+    setBusyKey(row.policyKey);
     try {
       const r = await fetch("/api/config", {
         method: "PUT",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ groupPolicies: { [String(groupId)]: null } }),
+        body: JSON.stringify({ groupPolicies: { [row.policyKey]: null } }),
       }).then((x) => x.json());
       if (r.ok) {
-        toast.success(`已恢复跟随全局: ${name(groupId)}`);
-        if (editing?.groupId === groupId) setEditing(null);
+        toast.success(
+          `已恢复跟随全局: ${channelLabel(row.channel)} · ${rowLabel(row, name)}`
+        );
+        if (editing?.policyKey === row.policyKey) setEditing(null);
         await refresh();
       } else toast.error(r.error || "清除失败");
     } catch (e) {
       toast.error(e instanceof Error ? e.message : String(e));
     } finally {
-      setBusyId(null);
+      setBusyKey(null);
     }
   }
 
   return (
     <PageShell>
       <PageHeader
-        title="生效群"
-        description={`按群开关机器人应答，并覆盖主动补位 / 转人工通知策略。${overrideCount ? `当前 ${overrideCount} 个群有独立策略。` : "未设置覆盖时全部跟随全局配置。"}`}
+        title="生效会话"
+        description={`按会话开关机器人应答，并覆盖主动补位 / 转人工通知策略。${overrideCount ? `当前 ${overrideCount} 个会话有独立策略。` : "未设置覆盖时全部跟随全局配置。"}`}
       />
 
       {globals && (
@@ -233,26 +264,30 @@ export default function GroupsPage() {
           <MetricBadge icon={Timer} label="静默阈值" value={min(globals.proactiveSilenceMs)} />
           <MetricBadge icon={Bell} label="转人工通知" value="开" tone="primary" />
           {overrideCount > 0 && (
-            <MetricBadge icon={Settings2} label="独立策略" value={`${overrideCount} 群`} />
+            <MetricBadge icon={Settings2} label="独立策略" value={`${overrideCount} 会话`} />
           )}
         </MetricBadgeRow>
       )}
 
-      <SectionCard title="群活动与策略" icon={Users} description="可在配置页修改全局默认；表格内可按群覆盖。">
+      <SectionCard
+        title="会话活动与策略"
+        icon={Users}
+        description="可在配置页修改全局默认；表格内可按会话覆盖。"
+      >
         <DataState
           loading={loading}
           error={error}
           empty={rows.length === 0}
           onRetry={refresh}
           emptyIcon={Users}
-          emptyTitle="暂无群活动"
-          emptyDescription="生效群有消息后会出现在这里。也可先在配置页勾选生效群。"
+          emptyTitle="暂无会话活动"
+          emptyDescription="生效会话有消息后会出现在这里。也可先在配置页勾选生效会话。"
           skeleton={<Skeleton className="h-40 w-full" />}
         >
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>群</TableHead>
+                <TableHead>会话</TableHead>
                 <TableHead>生效</TableHead>
                 <TableHead>主动补位</TableHead>
                 <TableHead>静默</TableHead>
@@ -264,21 +299,28 @@ export default function GroupsPage() {
             </TableHeader>
             <TableBody>
               {rows.map((r) => (
-                <TableRow key={r.groupId}>
+                <TableRow key={r.policyKey}>
                   <TableCell className="font-medium">
                     <div className="flex flex-col gap-0.5">
-                      <span>{name(r.groupId)}</span>
-                      <span className="text-muted-foreground text-xs tabular-nums">{r.groupId}</span>
+                      <div className="flex items-center gap-1.5">
+                        <Badge variant="outline" className="text-[10px] px-1.5">
+                          {channelLabel(r.channel)}
+                        </Badge>
+                        <span>{rowLabel(r, name)}</span>
+                      </div>
+                      <span className="text-muted-foreground font-mono text-xs">{r.chatId}</span>
                     </div>
                   </TableCell>
                   <TableCell>
                     <div className="flex items-center gap-2">
                       <Switch
                         checked={r.enabled}
-                        disabled={busyId === r.groupId}
-                        onCheckedChange={(v) => toggle(r.groupId, v)}
+                        disabled={busyKey === r.policyKey}
+                        onCheckedChange={(v) => toggle(r, v)}
                       />
-                      <Badge variant={r.enabled ? "default" : "secondary"}>{r.enabled ? "生效" : "未生效"}</Badge>
+                      <Badge variant={r.enabled ? "default" : "secondary"}>
+                        {r.enabled ? "生效" : "未生效"}
+                      </Badge>
                     </div>
                   </TableCell>
                   <TableCell>
@@ -323,9 +365,9 @@ export default function GroupsPage() {
                         <Button
                           size="sm"
                           variant="ghost"
-                          disabled={busyId === r.groupId}
+                          disabled={busyKey === r.policyKey}
                           title="清除覆盖，跟随全局"
-                          onClick={() => clearPolicy(r.groupId)}
+                          onClick={() => clearPolicy(r)}
                         >
                           <RotateCcw data-icon="inline-start" />
                           清除
@@ -343,13 +385,22 @@ export default function GroupsPage() {
       <Sheet open={editing !== null} onOpenChange={(o) => !o && setEditing(null)}>
         <SheetContent className="flex w-full flex-col sm:max-w-md">
           <SheetHeader>
-            <SheetTitle>群策略 · {editing ? name(editing.groupId) : ""}</SheetTitle>
+            <SheetTitle>
+              会话策略 · {editing ? `${channelLabel(editing.channel)} · ${rowLabel(editing, name)}` : ""}
+            </SheetTitle>
             <SheetDescription>
               未覆盖的项跟随全局配置。
+              {editing && (
+                <>
+                  {" "}
+                  <span className="font-mono text-xs">{editing.policyKey}</span>
+                </>
+              )}
               {globals && (
                 <>
-                  {" "}当前全局:主动 {globals.proactiveEnabled ? "开" : "关"} · 静默 {min(globals.proactiveSilenceMs)} ·
-                  转人工通知开。
+                  {" "}
+                  当前全局:主动 {globals.proactiveEnabled ? "开" : "关"} · 静默{" "}
+                  {min(globals.proactiveSilenceMs)} · 转人工通知开。
                 </>
               )}
             </SheetDescription>
@@ -412,7 +463,9 @@ export default function GroupsPage() {
                     <SelectItem value="off">不通知</SelectItem>
                   </SelectContent>
                 </Select>
-                <FieldDescription>仅控制转人工时是否向管理群发消息;会话仍会进入人工接待。</FieldDescription>
+                <FieldDescription>
+                  仅控制转人工时是否向管理群发消息;会话仍会进入人工接待。
+                </FieldDescription>
               </Field>
             </FieldGroup>
           </div>
@@ -422,7 +475,7 @@ export default function GroupsPage() {
               <Button
                 variant="outline"
                 disabled={savingPolicy}
-                onClick={() => editing && clearPolicy(editing.groupId)}
+                onClick={() => editing && clearPolicy(editing)}
               >
                 <RotateCcw data-icon="inline-start" />
                 全部跟随全局

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -13,7 +13,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
           <header className="bg-background/95 supports-[backdrop-filter]:bg-background/80 sticky top-0 z-20 flex h-14 shrink-0 items-center gap-2 border-b px-3 backdrop-blur sm:px-4">
             <SidebarTrigger className="-ml-1 shrink-0" />
             <Separator orientation="vertical" className="mr-2 h-4 data-vertical:self-center" />
-            <span className="min-w-0 truncate text-sm font-medium">OneBot 客服 Agent</span>
+            <span className="min-w-0 truncate text-sm font-medium">客服 Agent</span>
             <HeaderStatus />
           </header>
           <div className="flex min-h-0 flex-1 flex-col overflow-auto p-3 sm:p-4 md:p-6">

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -59,7 +59,7 @@ const navGroups = [
     label: "系统",
     items: [
       { href: "/admin/config", label: "配置", icon: Settings },
-      { href: "/admin/groups", label: "生效群", icon: Users },
+      { href: "/admin/groups", label: "生效会话", icon: Users },
       { href: "/admin/capabilities", label: "能力", icon: Boxes },
       { href: "/admin/plugins", label: "插件", icon: Puzzle },
     ],

--- a/docs/superpowers/plans/2026-07-18-admin-channel-settings.md
+++ b/docs/superpowers/plans/2026-07-18-admin-channel-settings.md
@@ -1,0 +1,835 @@
+# 管理后台全面多通道设置 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 管理后台与 channel 模型对齐——配置页按通道分栏、管理面可选 QQ/TG、生效会话统一表并用 `policyKey` 写策略。
+
+**Architecture:** 后端 `adminSurface: ChatRef` 与 gateway/handoff 已跨通道；本次以 UI + 策略写路径修复为主，并补 TG 管理面回归测试。配置 API 契约不变。
+
+**Tech Stack:** Next.js 16 App Router、React client components、shadcn/ui、vitest、现有 `/api/config` 与 `/api/groups/activity`。Prettier：无分号、双引号。测试在 `tests/`。
+
+参考 spec：`docs/superpowers/specs/2026-07-18-admin-channel-settings-design.md`
+
+**分支：** `feat/admin-channel-settings`（从最新 main 开，勿直接提交 main）
+
+**验收总命令：** `pnpm typecheck && pnpm lint && pnpm test`
+
+---
+
+## 文件结构
+
+### 修改
+
+| 文件 | 职责 |
+|------|------|
+| `tests/lib/agent/gateway.test.ts` | 补 TG 管理面 `!reset` / `!resume` |
+| `tests/lib/agent/handoff-handler.test.ts` | 补 TG 管理面抄送（任意通道来源） |
+| `app/admin/groups/page.tsx` | 跨通道表、toggle/策略用 chat-ref + policyKey、文案 |
+| `app/admin/config/page.tsx` | Tab 重组、管理面独立 Tab + 选择器、文案 |
+| `components/app-sidebar.tsx` | 「生效群」→「生效会话」 |
+| `app/admin/layout.tsx` | 「OneBot 客服 Agent」→「客服 Agent」 |
+
+### 可选（仅当 config 页难读时）
+
+| 文件 | 职责 |
+|------|------|
+| `app/admin/config/helpers.ts` | `Cfg` 类型、`withQqChats` / `withTgChats` / `qqChatIds` / `tgChatIds` |
+
+### 不改（除非测试红）
+
+- `lib/agent/gateway.ts`、`lib/agent/handoff-handler.ts`（预期已正确）
+- `app/api/config/route.ts`、`app/api/groups/activity/route.ts`
+- `lib/config-store.ts`、`lib/channels/enabled-chats.ts`
+
+---
+
+### Task 1: 分支 + TG 管理面 gateway 测试
+
+**Files:**
+- Modify: `tests/lib/agent/gateway.test.ts`
+- Branch: `feat/admin-channel-settings`
+
+- [ ] **Step 1: 建分支**
+
+```bash
+cd /Users/ziyou/projects/prayer
+git checkout main
+git pull --ff-only 2>/dev/null || true
+git checkout -b feat/admin-channel-settings
+```
+
+- [ ] **Step 2: 在 gateway 测试文件末尾（最后一个 `it` 之后、文件 `describe` 闭合前）追加两个用例**
+
+在 `tests/lib/agent/gateway.test.ts` 中，参考现有「管理群 !reset」写法，追加：
+
+```ts
+  it("TG 管理面 !reset <key> → 清 resumeId 并回 TG", async () => {
+    bus.removeAllListeners()
+    registerGateway({
+      repo,
+      botQQ: 555,
+      adminSurface: { channel: "tg" as const, chatId: "-100999" },
+      enabledChats: [{ channel: "qq" as const, chatId: "1" }],
+      supportUrl: "https://example.com",
+    })
+    const sk = "qq:1:2"
+    repo.setSessionId(sk, "sid-tg-admin")
+    const p = new Promise<any>((res) => bus.once("action.send", res))
+    bus.emit("message.received", {
+      channel: "tg" as const,
+      chatId: "-100999",
+      userId: "7",
+      messageId: "tg-reset-1",
+      rawText: `!reset ${sk}`,
+      atList: [],
+    })
+    const a = await p
+    expect(a.channel).toBe("tg")
+    expect(a.chatId).toBe("-100999")
+    expect(a.text).toContain(sk)
+    expect(repo.getResumeId(sk)).toBeUndefined()
+  })
+
+  it("TG 管理面 !resume <key> → handoff.resumed", async () => {
+    bus.removeAllListeners()
+    registerGateway({
+      repo,
+      botQQ: 555,
+      adminSurface: { channel: "tg" as const, chatId: "-100999" },
+      enabledChats: [{ channel: "qq" as const, chatId: "1" }],
+      supportUrl: "https://example.com",
+    })
+    const sk = "qq:1:2"
+    const p = new Promise<any>((res) => bus.once("handoff.resumed", res))
+    bus.emit("message.received", {
+      channel: "tg" as const,
+      chatId: "-100999",
+      userId: "7",
+      messageId: "tg-resume-1",
+      rawText: `!resume ${sk}`,
+      atList: [],
+    })
+    const h = await p
+    expect(h.sessionKey).toBe(sk)
+    expect(h.by).toBe("admin")
+  })
+```
+
+- [ ] **Step 3: 跑测试**
+
+```bash
+pnpm vitest run tests/lib/agent/gateway.test.ts
+```
+
+Expected: 全部 PASS（若 FAIL，先读 `lib/agent/gateway.ts` 管理面分支再最小修，再重跑）
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/lib/agent/gateway.test.ts
+git commit -m "$(cat <<'EOF'
+test(gateway): 覆盖 TG 管理面 !reset / !resume
+
+EOF
+)"
+```
+
+---
+
+### Task 2: TG 管理面 handoff 抄送测试
+
+**Files:**
+- Modify: `tests/lib/agent/handoff-handler.test.ts`
+
+- [ ] **Step 1: 在文件末尾 `describe` 闭合前追加用例**
+
+```ts
+  it("adminSurface 为 TG 时 QQ 用户 handoff → 通知发 TG", async () => {
+    bus.removeAllListeners()
+    repo = new Repo(openDb(":memory:"))
+    registerHandoffHandler({
+      repo,
+      adminSurface: { channel: "tg" as const, chatId: "-100999" },
+      handoffTimeoutMin: 30,
+      scanMs: 60_000,
+    })
+    const sends: any[] = []
+    bus.on("action.send", (a) => sends.push(a))
+    bus.emit("handoff.requested", {
+      channel: "qq" as const,
+      sessionKey: SK,
+      chatId: "1",
+      userId: "2",
+      lastQuestion: "退款",
+      reason: "user",
+    })
+    await new Promise((r) => setTimeout(r, 20))
+    expect(repo.isHumanMode(SK)).toBe(true)
+    expect(
+      sends.some(
+        (s) =>
+          s.channel === "qq" && s.chatId === "1" && s.text.includes("转接")
+      )
+    ).toBe(true)
+    expect(
+      sends.some(
+        (s) =>
+          s.channel === "tg" &&
+          s.chatId === "-100999" &&
+          s.text.includes("转人工") &&
+          s.text.includes(SK)
+      )
+    ).toBe(true)
+    // 不应再抄送到旧 QQ 管理面
+    expect(
+      sends.filter((s) => s.channel === "qq" && s.chatId === "999").length
+    ).toBe(0)
+  })
+
+  it("adminSurface 为 TG 时 TG 用户 handoff → 用户回 TG，通知也发 TG 管理面", async () => {
+    bus.removeAllListeners()
+    repo = new Repo(openDb(":memory:"))
+    registerHandoffHandler({
+      repo,
+      adminSurface: { channel: "tg" as const, chatId: "-100999" },
+      handoffTimeoutMin: 30,
+      scanMs: 60_000,
+    })
+    const sends: any[] = []
+    bus.on("action.send", (a) => sends.push(a))
+    bus.emit("handoff.requested", {
+      channel: "tg" as const,
+      sessionKey: "tg:-1001:42",
+      chatId: "-1001",
+      userId: "42",
+      lastQuestion: "怎么退款",
+      reason: "user",
+    })
+    await new Promise((r) => setTimeout(r, 20))
+    expect(
+      sends.some(
+        (s) =>
+          s.channel === "tg" &&
+          s.chatId === "-1001" &&
+          s.text.includes("转接")
+      )
+    ).toBe(true)
+    expect(
+      sends.some(
+        (s) =>
+          s.channel === "tg" &&
+          s.chatId === "-100999" &&
+          s.text.includes("转人工")
+      )
+    ).toBe(true)
+  })
+```
+
+注意：原用例「TG 用户 handoff → 通知发 adminSurface(QQ)」**保留**（QQ 管理面回归）。
+
+- [ ] **Step 2: 跑测试**
+
+```bash
+pnpm vitest run tests/lib/agent/handoff-handler.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/lib/agent/handoff-handler.test.ts
+git commit -m "$(cat <<'EOF'
+test(handoff): 覆盖 TG 管理面跨通道抄送
+
+EOF
+)"
+```
+
+---
+
+### Task 3: 生效会话页 — 类型与写路径（policyKey + 跨通道 toggle）
+
+**Files:**
+- Modify: `app/admin/groups/page.tsx`
+
+- [ ] **Step 1: 更新 Row 类型与 busy 主键**
+
+将：
+
+```ts
+interface Row {
+  groupId: number;
+  enabled: boolean;
+  // ...
+}
+```
+
+改为（保留 `groupId` 兼容字段）：
+
+```ts
+type ChannelId = "qq" | "tg" | "discord";
+
+interface Row {
+  channel: ChannelId;
+  chatId: string;
+  /** 兼容旧字段；勿作主键 */
+  groupId: number;
+  enabled: boolean;
+  messageCount: number;
+  lastTs: number;
+  cursor: number;
+  sedimentedCount: number;
+  policy: GroupPolicy;
+  hasOverride: boolean;
+  policyKey: string;
+  effective: {
+    proactiveEnabled: boolean;
+    proactiveSilenceMs: number;
+    notifyAdminOnHandoff: boolean;
+  };
+}
+```
+
+状态：
+
+```ts
+const [busyKey, setBusyKey] = useState<string | null>(null);
+// 删除 busyId: number | null
+```
+
+显示名辅助（文件内局部即可）：
+
+```ts
+function rowLabel(r: Pick<Row, "channel" | "chatId" | "groupId">, nameFn: (id: number) => string): string {
+  if (r.channel === "qq" && r.groupId > 0) return nameFn(r.groupId);
+  if (r.channel === "tg" && r.groupId !== 0) {
+    const n = nameFn(r.groupId);
+    if (n && n !== String(r.groupId)) return n;
+  }
+  return r.chatId;
+}
+
+function channelLabel(c: ChannelId): string {
+  if (c === "qq") return "QQ";
+  if (c === "tg") return "TG";
+  return c;
+}
+```
+
+- [ ] **Step 2: 重写 `toggle` / `savePolicy` / `clearPolicy`**
+
+```ts
+async function toggle(row: Row, enable: boolean) {
+  setBusyKey(row.policyKey);
+  try {
+    const cur = await fetch("/api/config").then((x) => x.json());
+    if (!cur.ok) {
+      toast.error(cur.error || "读取配置失败");
+      return;
+    }
+    type ChatRef = { channel: string; chatId: string };
+    const chats: ChatRef[] = Array.isArray(cur.data.enabledChats)
+      ? [...cur.data.enabledChats]
+      : [];
+    const others = chats.filter(
+      (c) => !(c.channel === row.channel && c.chatId === row.chatId)
+    );
+    const next: ChatRef[] = enable
+      ? [...others, { channel: row.channel, chatId: row.chatId }]
+      : others;
+    const r = await fetch("/api/config", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ enabledChats: next }),
+    }).then((x) => x.json());
+    if (r.ok) {
+      const label = `${channelLabel(row.channel)} · ${rowLabel(row, name)}`;
+      toast.success(enable ? `已生效: ${label}` : `已关闭: ${label}`);
+      if (enable) {
+        toast.message("用法提示", {
+          description: "群内问 bot 请 @机器人;重置发「重置」;转人工发「人工」。",
+        });
+      }
+      await refresh();
+    } else {
+      toast.error(r.error || "保存失败");
+    }
+  } catch (e) {
+    toast.error(e instanceof Error ? e.message : String(e));
+  } finally {
+    setBusyKey(null);
+  }
+}
+
+async function savePolicy() {
+  if (!editing) return;
+  setSavingPolicy(true);
+  try {
+    const policy: GroupPolicy = {};
+    const pe = triToBool(proactiveTri);
+    if (pe !== undefined) policy.proactiveEnabled = pe;
+    if (silenceMode === "custom") {
+      const m = Number(silenceMin);
+      if (!Number.isFinite(m) || m < 0) {
+        toast.error("静默阈值须为非负数字(分钟)");
+        return;
+      }
+      policy.proactiveSilenceMs = Math.round(m * 60_000);
+    }
+    const nh = triToBool(handoffTri);
+    if (nh !== undefined) policy.notifyAdminOnHandoff = nh;
+
+    const key = editing.policyKey;
+    const payload =
+      Object.keys(policy).length === 0
+        ? { groupPolicies: { [key]: null } }
+        : { groupPolicies: { [key]: policy } };
+
+    const r = await fetch("/api/config", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    }).then((x) => x.json());
+    if (r.ok) {
+      toast.success(`已保存 ${channelLabel(editing.channel)} · ${rowLabel(editing, name)} 的策略`);
+      setEditing(null);
+      await refresh();
+    } else {
+      toast.error(r.error || "保存失败");
+    }
+  } catch (e) {
+    toast.error(e instanceof Error ? e.message : String(e));
+  } finally {
+    setSavingPolicy(false);
+  }
+}
+
+async function clearPolicy(row: Row) {
+  setBusyKey(row.policyKey);
+  try {
+    const r = await fetch("/api/config", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ groupPolicies: { [row.policyKey]: null } }),
+    }).then((x) => x.json());
+    if (r.ok) {
+      toast.success(`已恢复跟随全局: ${channelLabel(row.channel)} · ${rowLabel(row, name)}`);
+      if (editing?.policyKey === row.policyKey) setEditing(null);
+      await refresh();
+    } else toast.error(r.error || "清除失败");
+  } catch (e) {
+    toast.error(e instanceof Error ? e.message : String(e));
+  } finally {
+    setBusyKey(null);
+  }
+}
+```
+
+- [ ] **Step 3: 更新 JSX 表头/行/Sheet**
+
+关键替换点：
+
+1. `PageHeader` title=`生效会话`；description 用「按会话开关…」
+2. SectionCard title=`会话活动与策略`；emptyTitle/emptyDescription 改为会话语义
+3. 表头第一列改为「会话」；在名称前加通道 Badge
+4. `TableRow key={r.policyKey}`（禁止 `key={r.groupId}`）
+5. Switch：`disabled={busyKey === r.policyKey}`，`onCheckedChange={(v) => toggle(r, v)}`
+6. clearPolicy：`onClick={() => clearPolicy(r)}`
+7. SheetTitle：`会话策略 · {editing ? `${channelLabel(editing.channel)} · ${rowLabel(editing, name)}` : ""}`
+8. SheetDescription 副标题可加 mono：`editing?.policyKey`
+9. 文案「转人工通知」保留；全局说明里「管理群」若有则改「管理面」
+10. MetricBadge「独立策略」value 用 `` `${overrideCount} 会话` ``
+
+会话单元格示例：
+
+```tsx
+<TableCell className="font-medium">
+  <div className="flex flex-col gap-0.5">
+    <div className="flex items-center gap-1.5">
+      <Badge variant="outline" className="text-[10px] px-1.5">
+        {channelLabel(r.channel)}
+      </Badge>
+      <span>{rowLabel(r, name)}</span>
+    </div>
+    <span className="text-muted-foreground font-mono text-xs">{r.chatId}</span>
+  </div>
+</TableCell>
+```
+
+- [ ] **Step 4: typecheck 该文件无 TS 错误**
+
+```bash
+pnpm typecheck
+```
+
+Expected: 无与 groups page 相关的错误
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/admin/groups/page.tsx
+git commit -m "$(cat <<'EOF'
+fix(admin): 生效会话页跨通道 toggle 与 policyKey
+
+EOF
+)"
+```
+
+---
+
+### Task 4: 配置页 — 管理面 Tab 与选择器
+
+**Files:**
+- Modify: `app/admin/config/page.tsx`
+
+- [ ] **Step 1: 删除 QQ-only 管理面辅助，改为通用**
+
+保留 `adminQqId` 可继续用于 QQ 分支，新增：
+
+```ts
+function setAdminSurface(
+  cfg: Cfg,
+  channel: "qq" | "tg" | null,
+  chatId: string
+): Cfg {
+  if (!channel || !chatId.trim()) {
+    return { ...cfg, adminSurface: null };
+  }
+  return {
+    ...cfg,
+    adminSurface: { channel, chatId: chatId.trim() },
+  };
+}
+```
+
+删除或停用仅写 QQ 的 `setAdminQq`；保存前校验：
+
+```ts
+// 在 save() 开头，setBusy(true) 之前
+if (cfg.adminSurface) {
+  const id = cfg.adminSurface.chatId?.trim();
+  if (!id) {
+    toast.error("管理面已选通道但未填会话");
+    return;
+  }
+}
+if (
+  cfg.adminSurface?.channel === "tg" &&
+  !(cfg.telegramBotToken && !cfg.telegramBotToken.includes("•")) &&
+  !String(cfg.telegramBotToken || "").trim()
+) {
+  // 掩码表示已有 token，无需警告；仅完全空字符串时警告
+}
+// 更稳妥：
+const tgTokenLooksEmpty =
+  !cfg.telegramBotToken || cfg.telegramBotToken.trim() === "";
+if (cfg.adminSurface?.channel === "tg" && tgTokenLooksEmpty) {
+  toast.message("提示", {
+    description: "TG 管理面已选，但 Bot Token 为空，通知可能发不出。",
+  });
+}
+```
+
+（掩码 `•` 表示已有 token，**不要**当空。）
+
+- [ ] **Step 2: 重组 TabsList**
+
+将：
+
+```tsx
+<TabsTrigger value="onebot">… OneBot</TabsTrigger>
+<TabsTrigger value="telegram">… Telegram</TabsTrigger>
+```
+
+改为（图标可继续用 `Cable` / `Send` / `Bell` 或 `Shield`）：
+
+```tsx
+<TabsTrigger value="qq"><Cable data-icon="inline-start" /> QQ 通道</TabsTrigger>
+<TabsTrigger value="tg"><Send data-icon="inline-start" /> TG 通道</TabsTrigger>
+<TabsTrigger value="admin"><Bell data-icon="inline-start" /> 管理面</TabsTrigger>
+```
+
+对应 `TabsContent`：
+
+- `value="onebot"` → `value="qq"`（内容：连接 + 生效群 + extraAt；**移出** adminSurface 与 handoffTimeoutMin）
+- `value="telegram"` → `value="tg"`（内容不变）
+- **新建** `value="admin"`：
+
+```tsx
+<TabsContent value="admin">
+  <SectionCard
+    title="管理面"
+    description="转人工/反思/用量告警抄送与 !reset / !resume 落点。可与生效白名单无关。"
+  >
+    <FieldGroup>
+      <Field>
+        <FieldLabel>通道</FieldLabel>
+        <Select
+          value={
+            cfg.adminSurface?.channel === "qq"
+              ? "qq"
+              : cfg.adminSurface?.channel === "tg"
+                ? "tg"
+                : "none"
+          }
+          onValueChange={(v) => {
+            if (v === "none") {
+              setCfg({ ...cfg, adminSurface: null });
+              return;
+            }
+            if (v === "qq") {
+              const prev =
+                cfg.adminSurface?.channel === "qq"
+                  ? cfg.adminSurface.chatId
+                  : "";
+              setCfg({
+                ...cfg,
+                adminSurface: prev
+                  ? { channel: "qq", chatId: prev }
+                  : { channel: "qq", chatId: "" },
+              });
+              return;
+            }
+            if (v === "tg") {
+              const prev =
+                cfg.adminSurface?.channel === "tg"
+                  ? cfg.adminSurface.chatId
+                  : enabledTgIds[0] ?? "";
+              setCfg({
+                ...cfg,
+                adminSurface: { channel: "tg", chatId: prev },
+              });
+            }
+          }}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="选择管理面通道" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="none">无（关闭）</SelectItem>
+            <SelectItem value="qq">QQ</SelectItem>
+            <SelectItem value="tg">Telegram</SelectItem>
+          </SelectContent>
+        </Select>
+      </Field>
+
+      {cfg.adminSurface?.channel === "qq" && (
+        <Field>
+          <FieldLabel>QQ 管理群</FieldLabel>
+          {groups ? (
+            <Select
+              value={cfg.adminSurface.chatId || ""}
+              onValueChange={(v) =>
+                setCfg({
+                  ...cfg,
+                  adminSurface: { channel: "qq", chatId: v },
+                })
+              }
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="选择管理群" />
+              </SelectTrigger>
+              <SelectContent>
+                {adminGroupOptions().map((g) => (
+                  <SelectItem key={g.groupId} value={String(g.groupId)}>
+                    {g.groupName} ({g.groupId})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <FieldDescription>
+              {groupsLoading ? "正在获取群列表…" : "bot 未连接,无法获取群列表。"}
+            </FieldDescription>
+          )}
+        </Field>
+      )}
+
+      {cfg.adminSurface?.channel === "tg" && (
+        <Field>
+          <FieldLabel>TG 管理 Chat</FieldLabel>
+          {enabledTgIds.length > 0 ? (
+            <Select
+              value={
+                enabledTgIds.includes(cfg.adminSurface.chatId)
+                  ? cfg.adminSurface.chatId
+                  : "__custom__"
+              }
+              onValueChange={(v) => {
+                if (v === "__custom__") return;
+                setCfg({
+                  ...cfg,
+                  adminSurface: { channel: "tg", chatId: v },
+                });
+              }}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="从生效 Chat 选择" />
+              </SelectTrigger>
+              <SelectContent>
+                {enabledTgIds.map((id) => (
+                  <SelectItem key={id} value={id}>
+                    {id}
+                  </SelectItem>
+                ))}
+                <SelectItem value="__custom__">手填下方 ID…</SelectItem>
+              </SelectContent>
+            </Select>
+          ) : null}
+          <Input
+            className="mt-2 font-mono text-xs"
+            value={cfg.adminSurface.chatId}
+            placeholder="如 -1001234567890"
+            onChange={(e) =>
+              setCfg({
+                ...cfg,
+                adminSurface: { channel: "tg", chatId: e.target.value },
+              })
+            }
+          />
+          <FieldDescription>
+            字符串原样保存（可负号）。管理面不必在生效白名单内。
+          </FieldDescription>
+        </Field>
+      )}
+
+      <Field>
+        <FieldLabel htmlFor="handoffTimeoutMin">转人工超时(分钟)</FieldLabel>
+        <Input
+          id="handoffTimeoutMin"
+          inputMode="numeric"
+          value={num("handoffTimeoutMin")}
+          onChange={(e) => upd("handoffTimeoutMin", e.target.value)}
+        />
+        <FieldDescription>
+          转人工后无人处理超过此时长自动恢复自动答。默认 30 分钟。
+        </FieldDescription>
+      </Field>
+    </FieldGroup>
+  </SectionCard>
+</TabsContent>
+```
+
+- [ ] **Step 3: 从 QQ Tab 移除管理群号与 handoffTimeout；更新文案**
+
+- QQ 生效群 `FieldDescription`：`也可在「生效会话」页一键开关。`
+- 去掉「一期仅 QQ 管理面」类文案
+- PageHeader description：`修改后保存即生效。通道连接与业务参数分栏。`
+- 通知 Tab：`反思通知管理群` → `反思通知管理面`；Section description `向管理面推送的运行通知。`
+- 回复体验里若有「管理群告警」→「管理面告警」
+
+- [ ] **Step 4: 修正 `adminGroupOptions`**
+
+当 `adminSurface.channel === "qq"` 时，若当前 `chatId` 不在 groups 列表，注入占位项（与现逻辑类似，用 `cfg.adminSurface.chatId` 而非仅 `adminQq`）。
+
+- [ ] **Step 5: typecheck**
+
+```bash
+pnpm typecheck
+```
+
+Expected: PASS（或仅无 config 相关错误）
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/admin/config/page.tsx
+git commit -m "$(cat <<'EOF'
+feat(admin): 配置页通道分栏与跨通道管理面
+
+EOF
+)"
+```
+
+---
+
+### Task 5: 侧栏与顶栏文案
+
+**Files:**
+- Modify: `components/app-sidebar.tsx`
+- Modify: `app/admin/layout.tsx`
+
+- [ ] **Step 1: 侧栏**
+
+`components/app-sidebar.tsx` 中：
+
+```ts
+{ href: "/admin/groups", label: "生效会话", icon: Users },
+```
+
+（href 保持 `/admin/groups`）
+
+- [ ] **Step 2: 顶栏**
+
+`app/admin/layout.tsx`：
+
+```tsx
+<span className="min-w-0 truncate text-sm font-medium">客服 Agent</span>
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/app-sidebar.tsx app/admin/layout.tsx
+git commit -m "$(cat <<'EOF'
+fix(admin): 侧栏生效会话与顶栏去 OneBot 叙事
+
+EOF
+)"
+```
+
+---
+
+### Task 6: 全量验收
+
+**Files:** 无新文件（修红测若有）
+
+- [ ] **Step 1: 跑全量检查**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm test
+```
+
+Expected: 全部通过
+
+- [ ] **Step 2: 若有失败**
+
+- 仅改相关文件最小修复
+- 再跑失败用例直至绿
+- 单独 commit：`fix: …`
+
+- [ ] **Step 3: 对照 spec 手工清单（开发机有 bot 时）**
+
+1. 配置 QQ / TG 通道保存
+2. 管理面切 QQ / TG 各保存一次
+3. 生效会话页开关 TG 行、写策略、清覆盖
+4. 刷新后配置与策略仍在
+
+- [ ] **Step 4: 最终状态**
+
+```bash
+git log --oneline main..HEAD
+git status
+```
+
+Expected: 工作区干净；commits 对应 Task 1–5（+ 可选 fix）
+
+---
+
+## Spec 覆盖自检
+
+| Spec 要求 | Task |
+|-----------|------|
+| TG 管理面命令测试 | Task 1 |
+| 跨通道 handoff 抄送测试 | Task 2 |
+| 生效会话统一表 + policyKey | Task 3 |
+| 配置页 Tab + 管理面选择器 | Task 4 |
+| 侧栏/顶栏文案 | Task 5 |
+| typecheck/lint/test | Task 6 |
+| Discord 不做 | 全任务无 Discord UI |
+| 不改 config API 契约 | 无 Task 改 route |
+
+## 占位符自检
+
+计划内无 TBD/TODO；步骤含可粘贴代码与命令。

--- a/docs/superpowers/specs/2026-07-18-admin-channel-settings-design.md
+++ b/docs/superpowers/specs/2026-07-18-admin-channel-settings-design.md
@@ -1,0 +1,264 @@
+# 管理后台全面多通道（配置 + 生效会话 + 管理面）设计
+
+日期：2026-07-18  
+分支建议：`feat/admin-channel-settings`  
+状态：已确认（方案 A）
+
+## 1. 背景与目标
+
+后端已完成 Channel 插件化与 Telegram 接入：`enabledChats` / `adminSurface` 为 `ChatRef`，`ChannelRegistry` 分发 `action.send`，gateway / handoff / 反思通知等多处已按 `adminSurface.channel` 发送。
+
+管理后台仍残留 OneBot 时代叙事：
+
+- 配置页 Tab 为「OneBot / Telegram」，管理面选择器仅 QQ
+- 「生效群」页以 `groupId: number` 为主键，toggle/策略写路径偏 QQ
+- 顶栏文案「OneBot 客服 Agent」
+- 策略保存仍可能写裸群号 key，与 `policyKey(channel, chatId)` 不一致
+
+### 目标
+
+1. **配置页**：按「通道连接 + 通用业务」组织；管理面可选 QQ 或 TG
+2. **生效会话页**：统一表（`channel:chatId`），开关与策略覆盖跨通道
+3. **壳层文案**：去掉单通道主叙事
+4. **策略 key**：写路径统一 `policyKey`，不再写裸群号
+
+### 非目标
+
+- Discord 实现（仅类型预留；UI 不出现可配入口）
+- TG 私聊客服、Webhook
+- 新管理命令语法（仍用 `!reset` / `!resume` + sessionKey）
+- 整页重做 reflection / ranking / sessions 等运营页（仅修会坏的 channel 展示/key）
+
+## 2. 方案
+
+**方案 A：UI 先行 + 管理面「最小后端」**
+
+- 配置页改成通道视角；生效群页改成跨通道表格
+- 后端：`adminSurface` 已是 `ChatRef`；gateway / handoff / 反思 / 用量告警已按 surface 发送
+- 本次后端增量以 **补测试 + 修策略写 key / 文案** 为主；若测出隐含 QQ 假设再最小修补
+- TG 管理命令：复用文本门 `!reset` / `!resume`，不另做 Bot Command
+
+未选方案 B（两阶段半成品）与方案 C（新建通道中心页）。
+
+## 3. 范围与能力矩阵
+
+用户确认「全开」：
+
+| 能力 | 要求 |
+|------|------|
+| 运营通知抄送 | 转人工、反思沉淀/整理/升格、日用量告警 → `adminSurface` |
+| 管理命令 | 管理面会话内 `!reset` / `!resume` |
+| 跨通道 handoff | 任意通道用户转人工 → 通知到所选 QQ 或 TG 管理面 |
+| 生效会话统一表 | 一行一个 `channel:chatId`，策略同一套 |
+
+### 后端现状（可复用）
+
+| 能力 | 现状 |
+|------|------|
+| 管理命令 | gateway 已用 `isAdminSurface`，不绑 QQ |
+| handoff 抄送 | `handoff-handler` 已发到 `adminSurface` |
+| 任意通道转人工 | 有 adminSurface 即 emit，不限 QQ 来源 |
+| 反思/升格通知 | 已用 `adminSurface.channel` |
+| 用量告警 | runtime 已按 adminSurface 发 |
+| `/api/groups/activity` | 已返回 `channel` / `chatId` / `policyKey` |
+
+## 4. 配置页信息架构
+
+### 4.1 Tab 重组
+
+| 现 Tab | 新 Tab | 内容 |
+|--------|--------|------|
+| OneBot | **QQ 通道** | WS、token、botQQ、extraAtQQs、QQ 生效群勾选 |
+| Telegram | **TG 通道** | token、生效 chat、部署清单（Privacy 等） |
+| — | **管理面**（新） | `adminSurface` 选择 + 转人工超时 |
+| 回复体验 / Claude SDK / 会话 / 反思 / 主动回复 / 通知 / 存储 | **保持** | 文案「管理群」→「管理面」 |
+
+推荐顺序：
+
+`QQ 通道` → `TG 通道` → `管理面` → `回复体验` → `会话` → `反思` → `主动回复` → `通知` → `Claude SDK` → `存储`
+
+### 4.2 字段归属
+
+- **通道私有**：连接凭证、该通道生效白名单、通道特有触发（如 QQ `extraAtQQs`）
+- **跨通道业务**：`adminSurface`、`handoffTimeoutMin`、ACK、supportUrl、反思与主动参数等
+- **不再**把「管理群号」塞在 QQ 连接区
+
+### 4.3 管理面选择器
+
+1. **通道** Select：`QQ` | `Telegram` | `无（关闭）`
+2. **会话**
+   - QQ：群列表下拉（`/api/onebot/groups` 或统一 names API）
+   - TG：从 `enabledChats` 中 channel=tg 的列表选，**或**手填 chat id（字符串，可负）
+3. 保存：`adminSurface: { channel, chatId } | null`（与现 `/api/config` 一致）
+
+说明文案要点：
+
+- 管理命令仅在该会话生效
+- 通知（转人工 / 反思 / 用量）发到此会话
+- 管理面 **不必** 在生效白名单内（gateway 已豁免）
+
+校验：
+
+- 选了通道但 chatId 空 → 保存前 toast，不提交
+- TG 管理面 + token 空 → 警告「TG 未配置，通知发不出」但仍可保存
+
+### 4.4 生效白名单在配置页
+
+- QQ / TG 各自 Tab **仍可编辑**本通道 `enabledChats`（避免配置时来回跳页）
+- 描述链到「生效会话」页做细策略
+- 保存时合并 TG 草稿/批量框逻辑保留
+
+### 4.5 壳层命名
+
+| 位置 | 现文案 | 新文案 |
+|------|--------|--------|
+| `layout` 顶栏 | OneBot 客服 Agent | 客服 Agent |
+| 通知 Tab | 反思通知管理群 | 反思通知管理面 |
+| 侧栏 groups | 生效群 | 生效会话 |
+
+### 4.6 组件拆分
+
+`app/admin/config/page.tsx` 已偏大。实现时优先：
+
+- 抽出 `Cfg` / helpers，或按 Tab 子组件
+
+不强制一次大拆；以可读为准。
+
+### 4.7 不做的配置项
+
+- Discord 入口
+- 模型 / ANTHROPIC_*（仍只在 `settings.json`）
+- 清空 TG token 的特殊 UI（掩码 + 留空不覆盖）
+
+## 5. 生效会话页 + API / 策略 key
+
+### 5.1 定位
+
+| 项 | 现况 | 目标 |
+|----|------|------|
+| 路由 | `/admin/groups` | **保持**（书签/外链） |
+| 侧栏 / 标题 | 生效群 | **生效会话** |
+| 行主键 | `groupId: number` | **`channel` + `chatId`** |
+| 数据源 | `/api/groups/activity` | 同 API，前端用完整字段 |
+
+### 5.2 表格列
+
+- 通道 Badge（QQ / TG）
+- 会话显示名 + mono `chatId`
+- 生效 Switch
+- 消息数 / 最近活动
+- 策略摘要
+- 编辑策略 / 清除覆盖
+
+### 5.3 Toggle
+
+```ts
+const others = enabledChats.filter(
+  (c) => !(c.channel === row.channel && c.chatId === row.chatId)
+)
+const next = enable
+  ? [...others, { channel: row.channel, chatId: row.chatId }]
+  : others
+PUT /api/config { enabledChats: next }
+```
+
+禁止再写死 `channel === "qq"`。
+
+### 5.4 策略覆盖
+
+- **写**：`groupPolicies: { [policyKey(channel, chatId)]: policy | null }`
+  - 例：`qq:123456`、`tg:-1001234567890`
+- **读**：用服务端 `policy` / `effective` / `policyKey`
+- **兼容**：`getGroupPolicy` 对 QQ 裸键回退保留；新写只用新键
+- 可选：保存 QQ 策略时顺带 null 掉裸键（非必须）
+
+### 5.5 策略编辑 Sheet
+
+字段不变（主动补位 / 静默 / 转人工通知；三态 inherit）。  
+文案「管理群」→「管理面」。  
+标题：`{通道} · {显示名}`，副标题 `channel:chatId`。
+
+### 5.6 显示名
+
+- 短期可继续 `useGroupNames()` 对 `Number(chatId)`（TG 负 id 仍可用）
+- 优先能 `nameByChat(channel, chatId)`；`groupId===0` 时回退裸 `chatId`
+- **不强制** 本次重写整个 `lib/group-name.ts`
+
+### 5.7 API 契约
+
+`/api/groups/activity` 保持现返回形状；前端以 `channel` / `chatId` / `policyKey` 为主键，`groupId` 仅兼容字段。  
+本次可不改 route 逻辑。
+
+## 6. 后端增量
+
+| 模块 | 动作 |
+|------|------|
+| gateway / handoff / 反思 / 用量 | 基本不动；测出 QQ 假设再最小修 |
+| `/api/config` | 契约不动 |
+| `/api/groups/activity` | 可不改 |
+| config-store / migrate | 不动 |
+
+实现期必补测试：
+
+1. TG 管理面 `!reset` / `!resume`，回执 channel 为 `tg`
+2. TG 管理面 + QQ/TG 来源 handoff 通知目标正确
+3. 策略 key `tg:-100…` 读写命中（前端路径 + 既有 getGroupPolicy）
+
+## 7. 错误与边界
+
+| 场景 | 行为 |
+|------|------|
+| `adminSurface = null` | 人工关键词引导 supportUrl；不 emit handoff |
+| 管理面通道未连接 | 配置可保存；send 失败走现有 error 日志 |
+| 管理面不在 enabledChats | 允许 |
+| Discord | UI 不出现 |
+| 策略双键（裸 QQ + `qq:id`） | 读兼容；新写只用新键 |
+
+## 8. 测试与验收
+
+### 自动化
+
+- gateway：TG 管理面命令 + QQ 回归
+- handoff-handler：`adminSurface.channel === "tg"` 抄送正确；用户侧回原 channel
+- 全量：`pnpm typecheck && pnpm lint && pnpm test`
+
+### 手工
+
+1. QQ 连接 + 生效群 → 状态灯 QQ 正常
+2. TG token + chat → TG 灯正常
+3. 管理面 QQ → TG 用户「人工」→ QQ 管理面收到通知
+4. 管理面 TG → QQ 用户「人工」→ TG 管理面收到通知
+5. TG 管理面 `!resume <sessionKey>` → 用户侧恢复
+6. 生效会话页：开关 TG、写/清策略，刷新仍在
+
+### 成功标准
+
+- 后台无「OneBot 客服」主叙事；配置按通道分栏
+- 管理面可选 QQ 或 TG；通知与命令跟所选通道
+- 生效会话跨通道可开关、策略 key 为 `channel:chatId`
+- QQ 路径行为不变；检查命令全绿
+
+## 9. 交付顺序
+
+单功能分支、分层提交：
+
+1. chore/docs：本 spec 入库
+2. test：TG 管理面 gateway + handoff 覆盖
+3. fix(admin)：groups 页 policyKey + 跨通道 toggle
+4. feat(admin)：配置页 Tab + 管理面选择器
+5. fix(admin)：侧栏 / 顶栏文案
+6. 全量 typecheck / lint / test
+
+## 10. 风险
+
+| 风险 | 缓解 |
+|------|------|
+| 配置页改动面大 | 保持 PUT 契约；先测后 UI |
+| group-name 偏 number | 验收负 id；失败回退 chatId 字符串 |
+| 误把管理面设到业务群 | 文案说明；不强制与白名单互斥 |
+
+## 11. 相关文档
+
+- `docs/superpowers/specs/2026-07-17-channel-plugin-telegram-design.md`（Phase 3 UI 打磨 + 管理面一期限制 → 本 spec 升级）
+- `lib/channels/enabled-chats.ts`、`lib/agent/gateway.ts`、`lib/agent/handoff-handler.ts`
+- `app/admin/config/page.tsx`、`app/admin/groups/page.tsx`

--- a/tests/lib/agent/gateway.test.ts
+++ b/tests/lib/agent/gateway.test.ts
@@ -333,4 +333,55 @@ describe("gateway", () => {
     const q = await p
     expect(q.text).toBe("你好")
   })
+
+  it("TG 管理面 !reset <key> → 清 resumeId 并回 TG", async () => {
+    bus.removeAllListeners()
+    registerGateway({
+      repo,
+      botQQ: 555,
+      adminSurface: { channel: "tg" as const, chatId: "-100999" },
+      enabledChats: [{ channel: "qq" as const, chatId: "1" }],
+      supportUrl: "https://example.com",
+    })
+    const sk = "qq:1:2"
+    repo.setSessionId(sk, "sid-tg-admin")
+    const p = new Promise<any>((res) => bus.once("action.send", res))
+    bus.emit("message.received", {
+      channel: "tg" as const,
+      chatId: "-100999",
+      userId: "7",
+      messageId: "tg-reset-1",
+      rawText: `!reset ${sk}`,
+      atList: [],
+    })
+    const a = await p
+    expect(a.channel).toBe("tg")
+    expect(a.chatId).toBe("-100999")
+    expect(a.text).toContain(sk)
+    expect(repo.getResumeId(sk)).toBeUndefined()
+  })
+
+  it("TG 管理面 !resume <key> → handoff.resumed", async () => {
+    bus.removeAllListeners()
+    registerGateway({
+      repo,
+      botQQ: 555,
+      adminSurface: { channel: "tg" as const, chatId: "-100999" },
+      enabledChats: [{ channel: "qq" as const, chatId: "1" }],
+      supportUrl: "https://example.com",
+    })
+    const sk = "qq:1:2"
+    const p = new Promise<any>((res) => bus.once("handoff.resumed", res))
+    bus.emit("message.received", {
+      channel: "tg" as const,
+      chatId: "-100999",
+      userId: "7",
+      messageId: "tg-resume-1",
+      rawText: `!resume ${sk}`,
+      atList: [],
+    })
+    const h = await p
+    expect(h.sessionKey).toBe(sk)
+    expect(h.by).toBe("admin")
+  })
 })

--- a/tests/lib/agent/handoff-handler.test.ts
+++ b/tests/lib/agent/handoff-handler.test.ts
@@ -125,4 +125,84 @@ describe("handoff handler", () => {
       sends.filter((s) => s.channel === "tg" && s.text.includes("转人工")).length
     ).toBe(0)
   })
+
+  it("adminSurface 为 TG 时 QQ 用户 handoff → 通知发 TG", async () => {
+    bus.removeAllListeners()
+    repo = new Repo(openDb(":memory:"))
+    registerHandoffHandler({
+      repo,
+      adminSurface: { channel: "tg" as const, chatId: "-100999" },
+      handoffTimeoutMin: 30,
+      scanMs: 60_000,
+    })
+    const sends: any[] = []
+    bus.on("action.send", (a) => sends.push(a))
+    bus.emit("handoff.requested", {
+      channel: "qq" as const,
+      sessionKey: SK,
+      chatId: "1",
+      userId: "2",
+      lastQuestion: "退款",
+      reason: "user",
+    })
+    await new Promise((r) => setTimeout(r, 20))
+    expect(repo.isHumanMode(SK)).toBe(true)
+    expect(
+      sends.some(
+        (s) =>
+          s.channel === "qq" && s.chatId === "1" && s.text.includes("转接")
+      )
+    ).toBe(true)
+    expect(
+      sends.some(
+        (s) =>
+          s.channel === "tg" &&
+          s.chatId === "-100999" &&
+          s.text.includes("转人工") &&
+          s.text.includes(SK)
+      )
+    ).toBe(true)
+    // 不应再抄送到旧 QQ 管理面
+    expect(
+      sends.filter((s) => s.channel === "qq" && s.chatId === "999").length
+    ).toBe(0)
+  })
+
+  it("adminSurface 为 TG 时 TG 用户 handoff → 用户回 TG，通知也发 TG 管理面", async () => {
+    bus.removeAllListeners()
+    repo = new Repo(openDb(":memory:"))
+    registerHandoffHandler({
+      repo,
+      adminSurface: { channel: "tg" as const, chatId: "-100999" },
+      handoffTimeoutMin: 30,
+      scanMs: 60_000,
+    })
+    const sends: any[] = []
+    bus.on("action.send", (a) => sends.push(a))
+    bus.emit("handoff.requested", {
+      channel: "tg" as const,
+      sessionKey: "tg:-1001:42",
+      chatId: "-1001",
+      userId: "42",
+      lastQuestion: "怎么退款",
+      reason: "user",
+    })
+    await new Promise((r) => setTimeout(r, 20))
+    expect(
+      sends.some(
+        (s) =>
+          s.channel === "tg" &&
+          s.chatId === "-1001" &&
+          s.text.includes("转接")
+      )
+    ).toBe(true)
+    expect(
+      sends.some(
+        (s) =>
+          s.channel === "tg" &&
+          s.chatId === "-100999" &&
+          s.text.includes("转人工")
+      )
+    ).toBe(true)
+  })
 })


### PR DESCRIPTION
## Summary
- 配置页按通道分栏（QQ / TG / 管理面等），管理面支持跨通道 `adminSurface`
- 生效会话页统一 `enabledChats` + `policyKey` 跨通道开关与策略
- 侧栏/顶栏文案去 OneBot 单通道叙事
- TG 通道 Tab 对齐 QQ：单卡表单 + 生效群 Badge（无部署说明/批量粘贴）
- gateway / handoff 测试覆盖 TG 管理面 `!reset` / `!resume` 与抄送

## Test plan
- [ ] `pnpm typecheck && pnpm test`
- [ ] 打开 `/admin/config`：QQ / TG Tab 布局一致；改 Token、添加/删除 TG 生效群并保存
- [ ] 管理面可选 QQ 群或 TG chatId
- [ ] `/admin/groups`（生效会话）跨通道开关与策略覆盖正常
- [ ] TG 管理群 `!reset` / `!resume` 与 handoff 抄送（有 token 时）