### PR TITLE
feat(gateway): @ 前回看用户本人历史上下文

### DIFF
--- a/docs/superpowers/plans/2026-07-20-at-prior-context.md
+++ b/docs/superpowers/plans/2026-07-20-at-prior-context.md
@@ -1,0 +1,835 @@
+# @ 前回看用户本人历史（prior context）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 用户被 @ 时，gateway 将该用户在 `prior_since` 纪元内、本群最多 10 条近期发言拼进 agent prompt，修复「先提问再 @」拿不到上下文。
+
+**Architecture:** `group_messages` 已缓冲全量消息。新增 `sessions.prior_since` 作对话纪元；`Repo.recentUserGroupMessages` 按用户回看；gateway 在关键词之后查库并用 `formatPriorContext` 写入 `QualifiedMessage.text`。命令句（重置/帮助/转人工）不入 buffer，避免重置后污染 prior。
+
+**Tech Stack:** TypeScript、better-sqlite3、vitest、现有 bus/gateway/message-buffer。
+
+**Spec:** `docs/superpowers/specs/2026-07-20-at-prior-context-design.md`
+
+---
+
+## File map
+
+| 文件 | 职责 |
+|------|------|
+| `lib/db/index.ts` | `user_version` 3；`prior_since` 列；复合索引 |
+| `lib/db/repo.ts` | `priorSince` / `recentUserGroupMessages`；`clearResumeId`/`clearAllResumeIds` 推进纪元 |
+| `lib/agent/command-keywords.ts` | 共享 RESET/HELP/HANDOFF 正则 |
+| `lib/agent/gateway.ts` | 查 prior、format、空 @ 逻辑、body trim |
+| `lib/agent/message-buffer.ts` | 跳过命令句 |
+| `lib/assemble.ts` | 注册顺序注释 |
+| `tests/lib/db/repo.test.ts` | repo + 迁移 |
+| `tests/lib/agent/gateway.test.ts` | 端到端 prior |
+| `tests/lib/agent/message-buffer.test.ts` | 命令不缓冲 |
+| `tests/lib/agent/prior-context.test.ts` | format/clip 纯函数（新建） |
+
+---
+
+### Task 1: Schema — `prior_since` + 索引 + user_version 3
+
+**Files:**
+- Modify: `lib/db/index.ts`
+- Test: `tests/lib/db/repo.test.ts`（追加迁移用例）
+
+- [ ] **Step 1: 写失败测 — v2 库升级后有列**
+
+在 `tests/lib/db/repo.test.ts` 末尾追加：
+
+```ts
+describe("migrate prior_since (v3)", () => {
+  it("已是 v2 无 prior_since 的库 openDb 后补列且可读写", () => {
+    // 手工建「假 v2」：最小 sessions + group_messages，无 prior_since
+    const raw = new BetterSqlite3(":memory:")
+    raw.pragma("user_version = 2")
+    raw.exec(`
+      CREATE TABLE sessions (
+        key TEXT PRIMARY KEY,
+        session_id TEXT,
+        resume_id TEXT,
+        human_mode INTEGER NOT NULL DEFAULT 0,
+        human_since INTEGER,
+        last_question TEXT,
+        updated_at INTEGER NOT NULL DEFAULT (unixepoch('subsec') * 1000)
+      );
+      CREATE TABLE group_messages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        channel TEXT NOT NULL,
+        group_id TEXT NOT NULL,
+        user_id TEXT NOT NULL,
+        sender_role TEXT,
+        text TEXT NOT NULL,
+        message_id TEXT,
+        created_at INTEGER NOT NULL DEFAULT (unixepoch('subsec') * 1000)
+      );
+      CREATE TABLE config (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        updated_at INTEGER NOT NULL DEFAULT (unixepoch('subsec') * 1000)
+      );
+      CREATE TABLE seen_messages (
+        dedupe_key TEXT PRIMARY KEY,
+        created_at INTEGER NOT NULL DEFAULT (unixepoch('subsec') * 1000)
+      );
+    `)
+    // 需要 sqlite-vec：走 openDb 同路径。用临时文件复制不可行；
+    // 改为：openDb(":memory:", 3) 已是最新；单独测 ensure 逻辑：
+    // 关闭 raw，改测「openDb 后 sessions 含 prior_since」
+    raw.close()
+
+    const db2 = openDb(":memory:", 3)
+    const cols = db2
+      .prepare("PRAGMA table_info(sessions)")
+      .all() as { name: string }[]
+    expect(cols.map((c) => c.name)).toContain("prior_since")
+    const ver = Number(db2.pragma("user_version", { simple: true }))
+    expect(ver).toBeGreaterThanOrEqual(3)
+    db2.close()
+  })
+})
+```
+
+> 若 vitest 环境 `openDb(":memory:")` 已跑完整 migrate，`user_version>=3` 与列存在即可。更严的「旧 v2 文件升级」可在实现 `ensureSessionsPriorSince` 后用：先 `BetterSqlite3` 建 v2 表写盘，再 `openDb(path)`（需 load sqlite-vec — `openDb` 会 load）。**推荐**用 tmp 文件：
+
+```ts
+it("磁盘上的 v2 库升级补 prior_since", () => {
+  const dir = mkdtempSync(join(tmpdir(), "prayer-v2-"))
+  const path = join(dir, "t.db")
+  const raw = new BetterSqlite3(path)
+  raw.pragma("user_version = 2")
+  raw.exec(`/* 同上最小 sessions 无 prior_since + 空 group_messages 等必需要表可省略若 migrate else 只 createV2 */`)
+  raw.close()
+  const db2 = openDb(path, 3)
+  const names = (
+    db2.prepare("PRAGMA table_info(sessions)").all() as { name: string }[]
+  ).map((c) => c.name)
+  expect(names).toContain("prior_since")
+  expect(Number(db2.pragma("user_version", { simple: true }))).toBeGreaterThanOrEqual(3)
+  db2.close()
+  rmSync(dir, { recursive: true, force: true })
+})
+```
+
+注意：`openDb` 在 `version>=2` 时调 `createV2Tables`；若 sessions 已存在且无列，**必须**在 migrate 里 `ALTER TABLE`，否则测会失败——这正是本 task 要修的。
+
+- [ ] **Step 2: 跑测确认失败（列不存在或 version 仍为 2）**
+
+```bash
+pnpm vitest run tests/lib/db/repo.test.ts -t "prior_since"
+```
+
+Expected: FAIL（尚无 v3 迁移）
+
+- [ ] **Step 3: 实现迁移**
+
+在 `lib/db/index.ts`：
+
+1. `createV1Tables` / `createV2Tables` 的 `sessions` 增加 `prior_since INTEGER`。
+2. 新增：
+
+```ts
+function ensureSessionsPriorSince(db: Database.Database): void {
+  if (!tableExists(db, "sessions")) return
+  if (!tableColumns(db, "sessions").has("prior_since")) {
+    db.exec("ALTER TABLE sessions ADD COLUMN prior_since INTEGER")
+  }
+}
+
+function ensureGmUserTimeIndex(db: Database.Database): void {
+  if (!tableExists(db, "group_messages")) return
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_gm_channel_group_user_time
+      ON group_messages(channel, group_id, user_id, created_at, id)
+  `)
+}
+```
+
+3. 改 `migrate`：
+
+```ts
+function migrate(db: Database.Database, dim: number): void {
+  const version = userVersion(db)
+
+  if (version < 2) {
+    createV1Tables(db, dim)
+    applyV1Patches(db)
+    db.transaction(() => {
+      migrateToV2(db)
+    })()
+    setUserVersion(db, 2)
+  } else {
+    createV2Tables(db, dim)
+  }
+
+  // v3: prior_since + 用户回看索引（幂等，可从任意 >=2 状态进入）
+  if (userVersion(db) < 3) {
+    ensureSessionsPriorSince(db)
+    ensureGmUserTimeIndex(db)
+    setUserVersion(db, 3)
+  } else {
+    ensureSessionsPriorSince(db)
+    ensureGmUserTimeIndex(db)
+  }
+}
+```
+
+- [ ] **Step 4: 跑测通过**
+
+```bash
+pnpm vitest run tests/lib/db/repo.test.ts -t "prior_since"
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/db/index.ts tests/lib/db/repo.test.ts
+git commit -m "feat(db): sessions.prior_since 与用户消息索引 (v3)"
+```
+
+---
+
+### Task 2: Repo — 纪元与 recentUserGroupMessages
+
+**Files:**
+- Modify: `lib/db/repo.ts`
+- Test: `tests/lib/db/repo.test.ts`
+
+- [ ] **Step 1: 写失败测**
+
+```ts
+describe("Repo prior context", () => {
+  it("clearResumeId 推进 prior_since；边界前消息不可见", () => {
+    repo.bufferGroupMessage("qq", "1", "2", "member", "旧问题", "m1")
+    const before = Date.now()
+    // 确保缓冲 created_at <= now
+    repo.setSessionId("qq:1:2", "sid")
+    repo.clearResumeId("qq:1:2")
+    const since = repo.priorSince("qq:1:2")
+    expect(since).toBeGreaterThanOrEqual(before)
+    const rows = repo.recentUserGroupMessages("qq", "1", "2", 10, {
+      sinceTs: since,
+    })
+    expect(rows).toHaveLength(0)
+  })
+
+  it("recentUserGroupMessages 只返回该用户非空、升序、exclude、limit", () => {
+    repo.bufferGroupMessage("qq", "1", "2", null, "a", "1")
+    repo.bufferGroupMessage("qq", "1", "2", null, "b", "2")
+    repo.bufferGroupMessage("qq", "1", "9", null, "他人", "3")
+    repo.bufferGroupMessage("qq", "1", "2", null, "   ", "4") // 若 buffer 拒空则手工 INSERT
+    const rows = repo.recentUserGroupMessages("qq", "1", "2", 10, {
+      excludeMessageId: "2",
+    })
+    expect(rows.map((r) => r.text)).toEqual(["a"])
+  })
+
+  it("同 created_at 按 id 升序稳定", () => {
+    const t = Date.now()
+    db.prepare(
+      `INSERT INTO group_messages (channel, group_id, user_id, text, message_id, created_at)
+       VALUES ('qq','1','2','x','10',?), ('qq','1','2','y','11',?)`
+    ).run(t, t)
+    const rows = repo.recentUserGroupMessages("qq", "1", "2", 10)
+    expect(rows.map((r) => r.text)).toEqual(["x", "y"])
+  })
+
+  it("clearAllResumeIds 推进全部行 prior_since，返回值仍只计有 resume 的", () => {
+    repo.setSessionId("qq:1:a", "s1")
+    repo.setSessionId("qq:1:b", "s2")
+    repo.clearResumeId("qq:1:b")
+    const n = repo.clearAllResumeIds()
+    expect(n).toBe(1)
+    expect(repo.priorSince("qq:1:a")).toBeGreaterThan(0)
+    expect(repo.priorSince("qq:1:b")).toBeGreaterThan(0)
+  })
+})
+```
+
+若 `bufferGroupMessage` 对空文本仍写入，则 exclude 空文本由 SQL `length(trim(text))>0` 保证；message-buffer 本就不缓冲空串，repo 单测可直接 SQL insert。
+
+- [ ] **Step 2: 跑测 FAIL**
+
+```bash
+pnpm vitest run tests/lib/db/repo.test.ts -t "prior context"
+```
+
+- [ ] **Step 3: 实现 Repo 方法**
+
+```ts
+priorSince(key: string): number {
+  const row = this.db
+    .prepare("SELECT prior_since FROM sessions WHERE key = ?")
+    .get(key) as { prior_since: number | null } | undefined
+  return row?.prior_since ?? 0
+}
+
+// clearResumeId: upsert
+clearResumeId(key: string): void {
+  this.db
+    .prepare(
+      `INSERT INTO sessions (key, resume_id, prior_since, updated_at)
+       VALUES (?, NULL, unixepoch('subsec')*1000, unixepoch('subsec')*1000)
+       ON CONFLICT(key) DO UPDATE SET
+         resume_id = NULL,
+         prior_since = unixepoch('subsec')*1000,
+         updated_at = unixepoch('subsec')*1000`
+    )
+    .run(key)
+}
+
+clearAllResumeIds(): number {
+  const info = this.db
+    .prepare(
+      "UPDATE sessions SET resume_id = NULL, updated_at = unixepoch('subsec')*1000 WHERE resume_id IS NOT NULL"
+    )
+    .run()
+  this.db
+    .prepare(
+      `UPDATE sessions SET prior_since = unixepoch('subsec')*1000,
+         updated_at = unixepoch('subsec')*1000`
+    )
+    .run()
+  return info.changes
+}
+
+recentUserGroupMessages(
+  channel: string,
+  chatId: string,
+  userId: string,
+  limit: number,
+  opts?: { excludeMessageId?: string | null; sinceTs?: number }
+): { text: string; createdAt: number; messageId: string | null; id: number }[] {
+  if (limit <= 0) return []
+  const sinceTs = opts?.sinceTs ?? 0
+  const ex = opts?.excludeMessageId ?? null
+  const rows = this.db
+    .prepare(
+      `SELECT id, text, created_at, message_id FROM group_messages
+       WHERE channel = ? AND group_id = ? AND user_id = ?
+         AND length(trim(text)) > 0
+         AND created_at > ?
+         AND (? IS NULL OR message_id IS NULL OR CAST(message_id AS TEXT) != ?)
+       ORDER BY created_at DESC, id DESC
+       LIMIT ?`
+    )
+    .all(channel, chatId, userId, sinceTs, ex, ex, limit) as {
+    id: number
+    text: string
+    created_at: number
+    message_id: string | number | null
+  }[]
+  return rows
+    .map((r) => ({
+      id: r.id,
+      text: r.text,
+      createdAt: r.created_at,
+      messageId: r.message_id == null ? null : String(r.message_id),
+    }))
+    .reverse()
+}
+```
+
+- [ ] **Step 4: 跑测 PASS + 确认旧 clearResumeId 测仍过**
+
+```bash
+pnpm vitest run tests/lib/db/repo.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/db/repo.ts tests/lib/db/repo.test.ts
+git commit -m "feat(db): recentUserGroupMessages 与 prior_since 纪元"
+```
+
+---
+
+### Task 3: command-keywords + message-buffer 跳过命令
+
+**Files:**
+- Create: `lib/agent/command-keywords.ts`
+- Modify: `lib/agent/gateway.ts`（改为 import 关键词）
+- Modify: `lib/agent/message-buffer.ts`
+- Test: `tests/lib/agent/message-buffer.test.ts`
+
+- [ ] **Step 1: 抽取关键词**
+
+`lib/agent/command-keywords.ts`:
+
+```ts
+export const RESET_KEYWORDS =
+  /^\s*(重新开始|重置对话|重置会话|重置|\/new|\/reset|\/clear)\s*$/i
+
+export const HANDOFF_KEYWORDS = /^\s*(人工|转人工|人工客服|转接人工|客服)\s*$/i
+
+export const HELP_KEYWORDS = /^\s*(帮助|怎么用|使用说明|\/help|help)\s*$/i
+
+export function isCommandMessage(text: string): boolean {
+  return (
+    RESET_KEYWORDS.test(text) ||
+    HANDOFF_KEYWORDS.test(text) ||
+    HELP_KEYWORDS.test(text)
+  )
+}
+```
+
+gateway 删除本地常量，改为 `import { RESET_KEYWORDS, HANDOFF_KEYWORDS, HELP_KEYWORDS } from "./command-keywords"`。
+
+- [ ] **Step 2: buffer 跳过命令 — 失败测**
+
+```ts
+it("重置/帮助/转人工整句不缓冲", () => {
+  const stop = registerMessageBuffer({
+    repo,
+    botQQ: 1,
+    adminSurface: { channel: "qq" as const, chatId: "999" },
+    enabledChats: [{ channel: "qq" as const, chatId: "100" }],
+  })
+  for (const rawText of ["重置", "帮助", "人工", "怎么充值"]) {
+    bus.emit("message.received", msg({ rawText, messageId: rawText }))
+  }
+  const win = repo.groupMessageWindow("qq", "100", 0, 10)
+  expect(win.map((w) => w.text)).toEqual(["怎么充值"])
+  stop()
+})
+```
+
+- [ ] **Step 3: message-buffer 实现**
+
+```ts
+import { isCommandMessage } from "./command-keywords"
+// in onReceived, after empty check:
+if (isCommandMessage(msg.rawText)) return
+```
+
+- [ ] **Step 4: 跑测**
+
+```bash
+pnpm vitest run tests/lib/agent/message-buffer.test.ts tests/lib/agent/gateway.test.ts
+```
+
+Expected: PASS（gateway 关键词行为不变）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/agent/command-keywords.ts lib/agent/gateway.ts lib/agent/message-buffer.ts tests/lib/agent/message-buffer.test.ts
+git commit -m "feat(agent): 命令关键词共享且不入 group_messages 缓冲"
+```
+
+---
+
+### Task 4: formatPriorContext / clipPriorTexts 纯函数
+
+**Files:**
+- Create: `lib/agent/prior-context.ts`
+- Create: `tests/lib/agent/prior-context.test.ts`
+
+- [ ] **Step 1: 写测**
+
+```ts
+import { describe, it, expect } from "vitest"
+import {
+  formatPriorContext,
+  clipPriorTexts,
+  PRIOR_LINE_MAX_CHARS,
+  EMPTY_AT_PLACEHOLDER,
+} from "@/lib/agent/prior-context"
+
+describe("formatPriorContext", () => {
+  it("无 prior → 原样 body", () => {
+    expect(formatPriorContext([], "hi")).toBe("hi")
+    expect(formatPriorContext([], "")).toBe("")
+  })
+  it("有 prior + body", () => {
+    const s = formatPriorContext(["怎么充值"], "支付宝呢")
+    expect(s).toContain("【用户近期发言（@前，旧→新）】")
+    expect(s).toContain("- 怎么充值")
+    expect(s).toContain("【当前消息】")
+    expect(s).toContain("支付宝呢")
+  })
+  it("有 prior 无 body → 占位", () => {
+    const s = formatPriorContext(["问"], "")
+    expect(s).toContain(EMPTY_AT_PLACEHOLDER)
+  })
+  it("多行续行缩进", () => {
+    const s = formatPriorContext(["L1\nL2"], "x")
+    expect(s).toContain("- L1\n  L2")
+  })
+})
+
+describe("clipPriorTexts", () => {
+  it("单行超长截断", () => {
+    const long = "字".repeat(PRIOR_LINE_MAX_CHARS + 50)
+    const [one] = clipPriorTexts([long], 2000, PRIOR_LINE_MAX_CHARS)
+    expect(one.length).toBeLessThanOrEqual(PRIOR_LINE_MAX_CHARS)
+    expect(one.endsWith("…")).toBe(true)
+  })
+  it("总预算保留较新", () => {
+    const old = "旧".repeat(100)
+    const neu = "新".repeat(100)
+    const out = clipPriorTexts([old, neu], 150, 400)
+    expect(out.some((t) => t.includes("新"))).toBe(true)
+    expect(out.join("").length).toBeLessThanOrEqual(200)
+  })
+})
+```
+
+- [ ] **Step 2: 实现 `lib/agent/prior-context.ts`**
+
+```ts
+export const PRIOR_USER_CONTEXT_LIMIT = 10
+export const PRIOR_CONTEXT_MAX_CHARS = 2000
+export const PRIOR_LINE_MAX_CHARS = 400
+export const EMPTY_AT_PLACEHOLDER =
+  "（用户仅 @ 了 bot，无新正文；请结合近期发言作答）"
+
+function normalizeLine(text: string, lineMax: number): string {
+  let t = text.trim()
+  if (t.length > lineMax) t = t.slice(0, lineMax - 1) + "…"
+  return t.replace(/\n+/g, "\n").split("\n").map((line, i) =>
+    i === 0 ? line : `  ${line}`
+  ).join("\n")
+}
+
+/** texts 已是旧→新；从新到旧纳入直到 maxChars */
+export function clipPriorTexts(
+  texts: string[],
+  maxChars: number,
+  lineMax: number
+): string[] {
+  const kept: string[] = []
+  let used = 0
+  for (let i = texts.length - 1; i >= 0; i--) {
+    const line = normalizeLine(texts[i], lineMax)
+    const cost = line.length + 3 // "- " + "\n"
+    if (kept.length > 0 && used + cost > maxChars) break
+    if (kept.length === 0 && cost > maxChars) {
+      kept.push(line.slice(0, Math.max(1, maxChars - 1)) + "…")
+      break
+    }
+    kept.push(line)
+    used += cost
+  }
+  return kept.reverse()
+}
+
+export function formatPriorContext(prior: string[], currentBody: string): string {
+  if (!prior.length) return currentBody
+  const lines = prior.map((p) => `- ${p}`).join("\n")
+  const cur = currentBody.trim() ? currentBody.trim() : EMPTY_AT_PLACEHOLDER
+  return `【用户近期发言（@前，旧→新）】\n${lines}\n【当前消息】\n${cur}`
+}
+```
+
+注意：`clipPriorTexts` 应在 format **之前**做单行截断；format 收到的已是 clip 后文本。测里「多行」应对 **未 clip 的 format** 或 clip 内 normalize——上面 normalize 在 clip 内，format 只做 `- ${p}`。多行测应对 clip 输出或 format 输入已含 `\n  `。
+
+调整：要么 format 内 normalize，要么测 clip。推荐 **clip 内 normalize，format 信任输入**；多行测改为：
+
+```ts
+const clipped = clipPriorTexts(["L1\nL2"], 2000, 400)
+expect(formatPriorContext(clipped, "x")).toContain("- L1\n  L2")
+```
+
+- [ ] **Step 3: 跑测 PASS**
+
+```bash
+pnpm vitest run tests/lib/agent/prior-context.test.ts
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/agent/prior-context.ts tests/lib/agent/prior-context.test.ts
+git commit -m "feat(agent): formatPriorContext 与字符预算裁剪"
+```
+
+---
+
+### Task 5: Gateway 接线
+
+**Files:**
+- Modify: `lib/agent/gateway.ts`
+- Modify: `lib/assemble.ts`（注释）
+- Test: `tests/lib/agent/gateway.test.ts`
+
+- [ ] **Step 1: 追加 gateway 测例**
+
+```ts
+function seedPrior(texts: string[]) {
+  for (let i = 0; i < texts.length; i++) {
+    repo.bufferGroupMessage("qq", "1", "2", "member", texts[i], `p${i}`)
+  }
+}
+
+it("纯 @ 有 prior → qualified 含历史，不发用法说明", async () => {
+  seedPrior(["怎么充值？"])
+  const help = vi.fn()
+  bus.on("action.send", help)
+  const p = collectQualified()
+  bus.emit("message.received", qqMsg({ messageId: "200", rawText: "", atList: [BOT] }))
+  const q = await p
+  expect(q.text).toContain("怎么充值？")
+  expect(q.text).toContain("【当前消息】")
+  expect(help).not.toHaveBeenCalled()
+})
+
+it("空白 @ 无 prior → 用法说明", async () => {
+  const p = new Promise<any>((res) => bus.once("action.send", res))
+  bus.emit(
+    "message.received",
+    qqMsg({ messageId: "201", rawText: "  \n\t", atList: [BOT] })
+  )
+  const a = await p
+  expect(a.text).toContain("用法说明")
+})
+
+it("有 prior + 短正文", async () => {
+  seedPrior(["原问题"])
+  const q = await collectQualified()
+  // 需先挂 listener 再 emit — 与现测一致
+})
+
+// 完整写法见下「接线后」同文件批量添加
+
+it("重置后 prior 隔离", async () => {
+  seedPrior(["敏感旧问"])
+  repo.setSessionId(SK, "sid")
+  // @ 重置
+  await new Promise<any>((res) => {
+    bus.once("action.send", res)
+    bus.emit(
+      "message.received",
+      qqMsg({ messageId: "210", rawText: "重置", atList: [BOT] })
+    )
+  })
+  // 同步 buffer 不写入「重置」（Task 3）；prior_since 已推进
+  const spy = vi.fn()
+  bus.on("message.qualified", spy)
+  const p = new Promise<any>((res) => bus.once("action.send", res))
+  bus.emit(
+    "message.received",
+    qqMsg({ messageId: "211", rawText: "", atList: [BOT] })
+  )
+  const a = await p
+  expect(a.text).toContain("用法说明")
+  expect(spy).not.toHaveBeenCalled()
+})
+
+it("查 prior 抛错时有正文仍放行", async () => {
+  const spy = vi
+    .spyOn(repo, "recentUserGroupMessages")
+    .mockImplementation(() => {
+      throw new Error("db down")
+    })
+  const err = new Promise<any>((res) => bus.once("error.occurred", res))
+  const p = collectQualified()
+  bus.emit(
+    "message.received",
+    qqMsg({ messageId: "220", rawText: "还在吗", atList: [BOT] })
+  )
+  const q = await p
+  expect(q.text).toBe("还在吗")
+  const e = await err
+  expect(e.scope).toBe("gateway.prior-context")
+  expect(e.sessionKey).toBe(SK)
+  expect(e.channel).toBe("qq")
+  expect(e.chatId).toBe("1")
+  spy.mockRestore()
+})
+```
+
+补全「有 prior + 短正文」：
+
+```ts
+it("有 prior + 短正文拼进 text", async () => {
+  seedPrior(["原问题"])
+  const p = collectQualified()
+  bus.emit(
+    "message.received",
+    qqMsg({ messageId: "202", rawText: "帮我看看", atList: [BOT] })
+  )
+  const q = await p
+  expect(q.text).toContain("原问题")
+  expect(q.text).toContain("帮我看看")
+})
+```
+
+`lastQuestion`：
+
+```ts
+it("纯 @ 有 prior 时 lastQuestion 用 prior 末条", async () => {
+  seedPrior(["第一问", "第二问"])
+  const p = collectQualified()
+  bus.emit(
+    "message.received",
+    qqMsg({ messageId: "203", rawText: "", atList: [BOT] })
+  )
+  await p
+  const s = repo.listSessions().find((x) => x.key === SK)
+  expect(s?.lastQuestion).toBe("第二问")
+})
+```
+
+- [ ] **Step 2: 跑测 FAIL**
+
+```bash
+pnpm vitest run tests/lib/agent/gateway.test.ts -t "prior"
+```
+
+- [ ] **Step 3: 改 gateway `onReceived` 核心逻辑**
+
+在 dedupe 与 `sessionKey` 之后：
+
+```ts
+const body = (msg.rawText ?? "").trim()
+const hasBody = body.length > 0
+const hasImages = !!msg.images?.length
+
+// human-mode 块：RESET 仍用 RESET_KEYWORDS.test(msg.rawText) 或 test(body)
+// 重置/帮助/转人工：一律 body / rawText trim 后匹配
+
+// —— 关键词与 human 处理完后 ——
+let priorTexts: string[] = []
+try {
+  const since = repo.priorSince(sessionKey)
+  const rows = repo.recentUserGroupMessages(
+    channel,
+    chatId,
+    userId,
+    PRIOR_USER_CONTEXT_LIMIT,
+    { excludeMessageId: messageId, sinceTs: since }
+  )
+  priorTexts = clipPriorTexts(
+    rows.map((r) => r.text),
+    PRIOR_CONTEXT_MAX_CHARS,
+    PRIOR_LINE_MAX_CHARS
+  )
+} catch (err) {
+  bus.emit("error.occurred", {
+    scope: "gateway.prior-context",
+    err,
+    sessionKey,
+    channel,
+    chatId,
+  })
+  priorTexts = []
+}
+
+if (!hasBody && !hasImages && priorTexts.length === 0) {
+  sendText(channel, chatId, helpText(supportUrl), messageId)
+  bus.emit("resolution.recorded", {
+    kind: "ack",
+    sessionKey,
+    channel,
+    chatId,
+    userId,
+    detail: "empty-after-mention",
+  })
+  return
+}
+
+const text = formatPriorContext(priorTexts, body)
+const lastQ = body || priorTexts[priorTexts.length - 1] || ""
+if (lastQ) repo.setLastQuestion(sessionKey, lastQ)
+
+bus.emit("message.qualified", {
+  channel,
+  sessionKey,
+  chatId,
+  userId,
+  messageId,
+  text,
+  images: msg.images,
+  quoted: msg.quoted,
+  forwarded: msg.forwarded,
+})
+```
+
+**重要：** 删除原先「纯 @ 无正文」在 human-mode **之前**的空消息 early-return；空消息门移到 prior 查询之后。human-mode / 重置 / 帮助 / 转人工 保持在 prior 查询 **之前**，且匹配 `body`（`RESET_KEYWORDS.test(body)` 等）。
+
+human-mode 内对空 body 的 `@`：现网 empty 在 human 前就 return help。新顺序下 human-mode 先：
+
+```ts
+if (repo.isHumanMode(sessionKey)) {
+  if (RESET_KEYWORDS.test(body)) { ... }
+  return
+}
+```
+
+纯 `@` 在 human-mode 下仍静默（不 help）——与「human 不抢答」一致；若需 help，规格未要求，保持静默。
+
+- [ ] **Step 4: assemble 注释**
+
+```ts
+// gateway 必须先于 message-buffer：prior 回看时当前条尚未入库；
+// 另以 excludeMessageId 双保险。
+registerGateway({...}),
+...
+registerMessageBuffer({...}),
+```
+
+- [ ] **Step 5: 全量相关测**
+
+```bash
+pnpm vitest run tests/lib/agent/gateway.test.ts tests/lib/agent/message-buffer.test.ts tests/lib/agent/prior-context.test.ts tests/lib/db/repo.test.ts
+```
+
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/agent/gateway.ts lib/assemble.ts tests/lib/agent/gateway.test.ts
+git commit -m "feat(gateway): @ 触发时拼接用户 prior 上下文"
+```
+
+---
+
+### Task 6: 全量校验
+
+- [ ] **Step 1: typecheck + lint + test**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm test
+```
+
+Expected: 全部通过
+
+- [ ] **Step 2: 若有失败，修到绿再 commit**
+
+```bash
+git add -A
+git commit -m "fix: prior context 全量校验修复"
+```
+
+（无修复则跳过）
+
+---
+
+## Spec coverage checklist
+
+| Spec 要求 | Task |
+|-----------|------|
+| prior 10 条、仅本人 | T2, T5 |
+| prior_since 纪元 / 重置隔离 | T1, T2, T3, T5 |
+| trim 空 @ | T5 |
+| id 稳定排序 | T2 |
+| 复合索引 + v3 迁移 | T1 |
+| 字符预算 | T4, T5 |
+| 查库失败降级 | T5 |
+| 命令不入 buffer | T3 |
+| clearAll 全表 prior_since | T2 |
+| format 拼接 / 占位 | T4 |
+| assemble 顺序注释 | T5 |
+
+## 执行注意
+
+- Prettier：无分号、双引号。
+- 路径别名 `@/*`。
+- 改 agent 核心已有 spec；实现严格按本 plan，勿扩 scope。

--- a/docs/superpowers/specs/2026-07-20-at-prior-context-design.md
+++ b/docs/superpowers/specs/2026-07-20-at-prior-context-design.md
@@ -1,0 +1,341 @@
+# @ 前回看用户本人历史（prior context）设计
+
+日期：2026-07-20  
+状态：ready（Codex 两轮复查；阻断项已写进本文）  
+审查：`codex exec` gpt-5.6-terra ×2；第二轮仍 Block 的两项（重置入缓冲、v2 补列）已并入下文。
+
+## 背景与目标
+
+群聊里很多人不会用 bot：先发问题，下一条才 `@Bot`。
+
+现状（`lib/agent/gateway.ts`）：
+
+1. 未 `@` 的消息 → gateway 丢弃（`!triggered` return），只由 `message-buffer` 写入 `group_messages`。
+2. 纯 `@Bot` 无正文无图 → 回用法说明「问我请 @我…」（`empty-after-mention`）。
+3. `@Bot` 带短正文（如「帮我看看」）→ 只把本条送进 agent，上文丢失。
+
+**目标**：每次被 `@` 且将进入 agent 时，把 **@ 者本人** 在本群、**当前对话纪元（prior_since）之后**、**最多 10 条** 文本发言作为上下文交给 agent，覆盖「先问后 @」与「@ + 短补充」。
+
+**非目标**（YAGNI）：
+
+- 不拉同群其他人消息。
+- 不改「必须 @ 才进主链路」的门控。
+- 不改主动回复 / 反思 / 问题排行 poller。
+- 不做条数/时间窗/预算的后台可配置 UI（常量即可）。
+- 不回看图片/引用/转发历史（当前条的 `images`/`quoted`/`forwarded` 仍按现有逻辑）。
+
+## 选定方案
+
+**Gateway 查库 + 拼 preamble 进 `QualifiedMessage.text`**（方案 A）。
+
+- 原料：`group_messages` 已有全量缓冲（含未 @ 消息）。
+- 改动面：`repo` 查询 + 会话 `prior_since` + 索引 + `gateway` 拼接；orchestrator / agent 无需新字段。
+- 意图门 `classify(probe)` 自动看到历史（probe 含 `q.text`）。
+
+## 行为规格
+
+### 触发（不变）
+
+- `botMentioned` 或 `isAtTrigger(atList, botQQ, extraAtQQs)` 为真才继续。
+- 未 `@` → 不查 prior、不 emit `message.qualified`。
+
+### 正文归一化（C2）
+
+全文统一：
+
+```ts
+const body = (msg.rawText ?? "").trim()
+const hasBody = body.length > 0
+const hasImages = !!msg.images?.length
+```
+
+「无正文」= `!hasBody`。空格/换行/制表符的 `@` 与纯 `@` 同等。  
+空消息门、占位文案、`lastQuestion`、`formatPriorContext` 的 current 参数均用 `body`，不用裸 `rawText` 真值判断。
+
+### 对话纪元 `prior_since`（C1）
+
+产品语义：**当前对话纪元内**该用户在本群的近期发言，不是「该用户有史以来任意 10 条」。
+
+| 项 | 规则 |
+|----|------|
+| 存储 | `sessions.prior_since INTEGER NULL`（毫秒；`NULL`/缺行 = `0`，即无下界） |
+| 查询下界 | `created_at > prior_since`（严格大于） |
+| 何时推进 | `clearResumeId(key)`、`clearAllResumeIds()`（见下） |
+| 推进值 | SQLite `unixepoch('subsec')*1000`（与列默认一致，避免 JS/DB 时钟分叉） |
+| 管理面 `!reset <sessionKey>` | 调 `clearResumeId` → 推进该 key |
+| 不推进 | 普通 `@`、转人工、human-mode 进出（除非同时 reset） |
+
+#### 重置命令不得成为新 prior（第二轮 Critical）
+
+时序：gateway 内 `clearResumeId`（写 `prior_since=now`）→ 之后 message-buffer 才可能把本条「重置」写入 `group_messages`，其 `created_at` 往往 **>** `prior_since`，下一轮纯 `@` 会把「重置」当 prior 进 agent，验收失败。
+
+**强制规则：**
+
+1. **`message-buffer` 不缓冲** 与 gateway 相同的整句命令：`RESET_KEYWORDS` / `HELP_KEYWORDS` / `HANDOFF_KEYWORDS`（精确匹配，与 gateway 同源正则或抽到 `lib/agent/command-keywords.ts` 共享）。
+2. 管理面 `!reset` / `!resume` 本就不在生效群用户路径；无需额外处理。
+3. 不靠 `prior_since + 1ms` 等脆弱时钟技巧。
+
+端到端测例：缓冲两条业务消息 → 用户 `@`「重置」→ buffer **无**「重置」行且 `prior_since` 已推进 → 再纯 `@` → **用法说明**（无 prior），不得进 agent。
+
+#### `clearResumeId` / `clearAllResumeIds`
+
+- **`clearResumeId(key)`**：upsert 语义——行不存在则 `INSERT (key, resume_id=NULL, prior_since=now)`；存在则 `resume_id=NULL, prior_since=now, updated_at=now`。
+- **`clearAllResumeIds()`**（第二轮 Important）：
+  1. 返回值语义保持：**仅** `resume_id IS NOT NULL` 的行数（后台文案「清了 N 个会话」不变）。
+  2. 另执行：`UPDATE sessions SET prior_since = now, updated_at = now` **对全部 sessions 行**（含本已 `resume_id IS NULL` 的遗留行），避免「已无 resume 但 prior_since 仍 NULL」的会话在一键重置后仍带全历史 prior。
+
+### 回看规则
+
+| 项 | 规则 |
+|----|------|
+| 维度 | `channel` + `chatId` + **同一 `userId`** + `created_at > prior_since` |
+| 上限条数 | `PRIOR_USER_CONTEXT_LIMIT = 10` |
+| 字符预算 | `PRIOR_CONTEXT_MAX_CHARS = 2000`（见下） |
+| 角色 | 不按 `sender_role` 过滤 |
+| 文本 | 仅 `length(trim(text)) > 0` |
+| 稳定顺序（I1） | SQL：`ORDER BY created_at DESC, id DESC LIMIT ?`；应用层 reverse → 升序 `(created_at ASC, id ASC)` |
+| 排除本条 | `excludeMessageId = msg.messageId`（防御 listener 顺序变更） |
+| 注册顺序 | `assemble` 中 `registerGateway` **必须**在 `registerMessageBuffer` 之前（注释锁定） |
+
+### 字符预算（I3）
+
+在已取到的最多 10 条（升序）上再裁：
+
+1. **当前消息优先**：`body` 不计入 prior 预算；始终完整保留（若单条极长，与改前一致，不在本特性截断）。
+2. **prior 从新到旧**纳入，累计 `format` 后文本长度（含列表前缀）≤ `PRIOR_CONTEXT_MAX_CHARS`；放不下的更旧消息丢弃。
+3. **单条 prior 上限** `PRIOR_LINE_MAX_CHARS = 400`：超出则 `trim` 后截断并加 `…`。
+4. 多行 prior：`trim` 后，内部换行改为续行缩进 `"  "`，保证每条视觉上仍是一个列表项（M2）。
+
+### 空 @ 行为
+
+| 情况 | 行为 |
+|------|------|
+| `!hasBody && !hasImages && prior.length === 0` | 用法说明 + `empty-after-mention` |
+| `!hasBody && !hasImages && prior.length > 0` | **进 agent** |
+| 纯图 @ | 仍放行；有 prior 则附上 |
+| `hasBody` | 本条 + prior 一并进 prompt |
+
+### 拼接格式
+
+有 prior 时：
+
+```
+【用户近期发言（@前，旧→新）】
+- 怎么充值？
+- 第一行
+  续行缩进
+【当前消息】
+帮我看看
+```
+
+纯 @ 有 prior：`【当前消息】` 下为  
+`（用户仅 @ 了 bot，无新正文；请结合近期发言作答）`。
+
+无 prior：`text === body`（可为空串），**不**包壳。
+
+`lastQuestion`：`body || priorTexts[priorTexts.length - 1] || ""`（空则不写）；截断仍走现有 `setLastQuestion` 的 500 字逻辑。
+
+### 分支顺序（M1）
+
+在 `triggered` 且 dedupe 通过后：
+
+1. **human-mode**（与现网一致；重置关键词在人工模式下仍可清上下文——现逻辑保留，并经 `clearResumeId` 推进 `prior_since`）。
+2. **重置 / 帮助 / 转人工**——只匹配 `body`（归一化后的 rawText），**不**查 prior。
+3. **查 prior**（try/catch 降级）。
+4. **空消息门**：`!hasBody && !hasImages && prior.length === 0` → 用法说明。
+5. `setLastQuestion` + emit `message.qualified`。
+
+这样「帮助/重置/转人工」不付 prior 查询成本；空 `@` 仍能在步骤 3–4 决定帮助 vs 进 agent。
+
+### 查库失败（I4）
+
+- try/catch：prior = `[]`，主链路继续（空 @ → 用法说明；有正文 → 仅当前条）。
+- `bus.emit("error.occurred", { scope: "gateway.prior-context", err, sessionKey, channel, chatId })`。
+- 测例必覆盖。
+
+## 组件改动
+
+### 1. Schema / 迁移（`lib/db/index.ts`）（第二轮 Critical：可执行升级）
+
+现网已是 `user_version = 2`；`CREATE TABLE IF NOT EXISTS sessions` **不会**给已有表加列。必须写清升级路径：
+
+**`user_version` 3**
+
+```
+migrate():
+  if version < 2: …现有 v1→v2…
+  if version < 3:
+    // 幂等：已是 v2 的生产库 / 刚升到 2 的库
+    ensureSessionsPriorSince(db)   // 见下
+    ensureGmUserTimeIndex(db)
+    setUserVersion(db, 3)
+  else:
+    createV2Tables(db, dim)       // 最终形态 DDL 含 prior_since
+    ensureSessionsPriorSince(db)  // 双保险
+    ensureGmUserTimeIndex(db)
+```
+
+**`ensureSessionsPriorSince`**
+
+```ts
+if (tableExists(sessions) && !tableColumns(sessions).has("prior_since")) {
+  db.exec("ALTER TABLE sessions ADD COLUMN prior_since INTEGER")
+}
+```
+
+**`createV1Tables` / `createV2Tables` 的 sessions DDL** 同步写入 `prior_since INTEGER`，保证全新库建表即带列。
+
+**索引**
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_gm_channel_group_user_time
+  ON group_messages(channel, group_id, user_id, created_at, id);
+```
+
+（与现有索引风格一致，不依赖 DESC 索引；查询 `ORDER BY created_at DESC, id DESC` 仍可走该前缀。）
+
+**迁移测例**：打开已是 v2、无 `prior_since` 的 fixture 库 → `openDb` 后列存在、读写 `priorSince`/`clearResumeId` 不抛。
+
+### 2. `Repo`（`lib/db/repo.ts`）
+
+**`clearResumeId` / `clearAllResumeIds`**：清 `resume_id` 同时 `prior_since = unixepoch('subsec')*1000`。  
+无 sessions 行时：`clearResumeId` 应 `INSERT ... prior_since=now` 或 upsert，保证后续查询有下界（重置时用户可能尚无 session 行——用户关键词重置路径会先有 sessionKey；`!reset` 亦然。若行不存在，upsert 建行只写 `prior_since`）。
+
+**`priorSince(sessionKey): number`**：读 `prior_since ?? 0`。
+
+**`recentUserGroupMessages`**：
+
+```ts
+recentUserGroupMessages(
+  channel: string,
+  chatId: string,
+  userId: string,
+  limit: number,
+  opts?: {
+    excludeMessageId?: string | null
+    sinceTs?: number // 默认 0；created_at > sinceTs
+  }
+): { text: string; createdAt: number; messageId: string | null; id: number }[]
+```
+
+SQL：
+
+```sql
+SELECT id, text, created_at, message_id FROM group_messages
+WHERE channel = ? AND group_id = ? AND user_id = ?
+  AND length(trim(text)) > 0
+  AND created_at > ?
+  AND (? IS NULL OR message_id IS NULL OR CAST(message_id AS TEXT) != ?)
+ORDER BY created_at DESC, id DESC
+LIMIT ?
+```
+
+（`message_id` 类型以现表为准；比较时统一转 string，与 `IncomingMessage.messageId` 一致。）
+
+应用层 reverse → 升序。`limit <= 0` → `[]`。
+
+### 3. 命令关键词共享（新小文件，可选但推荐）
+
+`lib/agent/command-keywords.ts`：导出 `RESET_KEYWORDS` / `HELP_KEYWORDS` / `HANDOFF_KEYWORDS`（从 gateway 挪出或 re-export），供 gateway 与 message-buffer 共用，避免两处正则漂移。
+
+### 4. `gateway`（`lib/agent/gateway.ts`）
+
+导出常量与纯函数（单测友好）：
+
+- `PRIOR_USER_CONTEXT_LIMIT = 10`
+- `PRIOR_CONTEXT_MAX_CHARS = 2000`
+- `PRIOR_LINE_MAX_CHARS = 400`
+- `formatPriorContext(prior: string[], currentBody: string): string`
+- `clipPriorTexts(texts: string[], maxChars, lineMax): string[]`（从新到旧纳入）
+
+接线见「分支顺序」。
+
+### 5. `message-buffer`
+
+在现有过滤之后增加：若 `RESET_KEYWORDS|HELP_KEYWORDS|HANDOFF_KEYWORDS` 命中 `rawText` → **不** `bufferGroupMessage`。单测覆盖。
+
+### 6. orchestrator / agent
+
+无 API 变更。
+
+### 7. `assemble.ts`
+
+gateway / message-buffer 注册处注释：顺序依赖 + prior 排除本条的双保险。
+
+## 数据流
+
+```
+message.received
+  ├─ gateway (先于 buffer)
+  │    ├─ !@ / 未生效 → return
+  │    ├─ dedupe
+  │    ├─ human-mode / 重置 / 帮助 / 转人工（仅 body；重置→clearResumeId→prior_since）
+  │    ├─ recentUserGroupMessages(..., sinceTs=priorSince(sessionKey))
+  │    ├─ 空@且无 prior → help
+  │    └─ message.qualified { text: formatPriorContext(clipped, body) }
+  └─ message-buffer
+       └─ bufferGroupMessage(当前条)
+```
+
+## 测试计划
+
+### `tests/lib/db/repo.test.ts`
+
+- 同用户多条、他人消息、空文本、`sinceTs`、`excludeMessageId`。
+- 相同 `created_at` 不同 `id` → 升序稳定（I1）。
+- `clearResumeId` 推进 `prior_since`；其后 `recentUserGroupMessages` 看不到边界前消息。
+
+### `tests/lib/agent/gateway.test.ts`
+
+- 预置两条历史 + 纯 `@` → qualified 含两条 + 占位；不发用法说明。
+- 历史 + `@ 帮我看看` → 含历史与正文。
+- 无历史纯 `@` / 仅空白 `@` → 用法说明 + `empty-after-mention`（C2）。
+- 历史含「重置」+ 当前 `@ 订单呢` → 不误触重置。
+- **重置后 prior 隔离（C1）**：缓冲 → `@` 成功带 prior → 用户「重置」→ 再纯 `@` → 用法说明。
+- 查库抛错（I4）：mock/spy repo 方法 throw → 有正文仍 qualified（无 prior 壳）；无正文 → help；`error.occurred` 一次且含 `sessionKey/channel/chatId`。
+- 超长 prior（I3）：单条 >400 被截断；总长受 2000 约束，保留较新。
+- 多行 prior（M2）：续行缩进。
+- `lastQuestion`：有 body 用 body；纯 @ 用 prior 末条。
+- 纯图无 prior：`text === ""` 仍放行（回归）。
+
+### 索引（I2）
+
+- 迁移存在；可选：内存库 `EXPLAIN QUERY PLAN` 含 `idx_gm_channel_group_user_time`（若测试环境易做则加，否则实现时手工验一次即可写进 plan）。
+
+## 风险与缓解
+
+| 风险 | 缓解 |
+|------|------|
+| 重置后仍带旧上下文 | `prior_since` + 测例 C1 |
+| 空白 `@` 误进 agent | 统一 `trim`（C2） |
+| 同毫秒顺序乱 | `id` 次级排序（I1） |
+| 高活跃群扫表 | 复合索引（I2） |
+| 超长 prompt | 条数 + 字符预算 + 单行上限（I3） |
+| 闲聊污染 | 仅本人、纪元内、≤10 条 |
+| listener 顺序 | 注释 + `excludeMessageId` |
+| 关键词误触 | 只匹配 `body`；查 prior 在关键词之后 |
+
+## 实现顺序（供 plan）
+
+1. Schema：`user_version` 3 + `ensureSessionsPriorSince` + 复合索引；v2 fixture 升级测  
+2. Repo：`clearResumeId` upsert 推进纪元、`clearAllResumeIds` 全表 `prior_since`、`priorSince`、`recentUserGroupMessages` + 单测  
+3. 抽 `command-keywords`；message-buffer 跳过命令句 + 单测  
+4. `formatPriorContext` / `clipPriorTexts` + gateway 接线 + 单测（含重置隔离）  
+5. assemble 注释  
+6. `pnpm typecheck && pnpm lint && pnpm test`  
+
+## 验收标准
+
+- 先发「怎么充值？」再纯 `@Bot` → 进 agent 作答，不回用法说明。  
+- 先发问题再 `@Bot 支付宝行吗` → agent 同时看到问题与补充。  
+- 无历史 / 仅空白的纯 `@` → 与改前一致（用法说明）。  
+- 「重置」后再纯 `@` → 不带重置前缓冲。  
+- 未 `@` 仍不触发主链路。  
+
+## 审查记录
+
+| 轮次 | 结论 | 处理 |
+|------|------|------|
+| Codex #1 | Block：C1 会话边界、C2 trim；I1–I4 | `prior_since`、统一 trim、id 排序、索引、预算、失败测 |
+| Codex #2 | Block：重置入缓冲成 prior；v2 无补列路径；clearAll 范围 | buffer 跳过命令句；`user_version` 3 幂等补列；`clearAllResumeIds` 全表推进 prior_since |
+| M1/M2 | Minor | 查库时机后移；多行缩进 |

--- a/lib/agent/command-keywords.ts
+++ b/lib/agent/command-keywords.ts
@@ -1,0 +1,14 @@
+export const RESET_KEYWORDS =
+  /^\s*(重新开始|重置对话|重置会话|重置|\/new|\/reset|\/clear)\s*$/i
+
+export const HANDOFF_KEYWORDS = /^\s*(人工|转人工|人工客服|转接人工|客服)\s*$/i
+
+export const HELP_KEYWORDS = /^\s*(帮助|怎么用|使用说明|\/help|help)\s*$/i
+
+export function isCommandMessage(text: string): boolean {
+  return (
+    RESET_KEYWORDS.test(text) ||
+    HANDOFF_KEYWORDS.test(text) ||
+    HELP_KEYWORDS.test(text)
+  )
+}

--- a/lib/agent/gateway.ts
+++ b/lib/agent/gateway.ts
@@ -13,6 +13,13 @@ import {
   HANDOFF_KEYWORDS,
   HELP_KEYWORDS,
 } from "./command-keywords"
+import {
+  PRIOR_USER_CONTEXT_LIMIT,
+  PRIOR_CONTEXT_MAX_CHARS,
+  PRIOR_LINE_MAX_CHARS,
+  formatPriorContext,
+  clipPriorTexts,
+} from "./prior-context"
 
 export interface GatewayDeps {
   repo: Repo
@@ -94,24 +101,15 @@ export function registerGateway(deps: GatewayDeps): () => void {
     if (!triggered) return
     if (repo.seenMessage(makeDedupeKey(channel, chatId, messageId))) return
     const sessionKey = makeSessionKey(channel, chatId, userId)
-    // 纯 @bot 无正文：回用法说明（常见「@ 了但无回复」）
-    if (!msg.rawText?.trim() && !msg.images?.length) {
-      sendText(channel, chatId, helpText(supportUrl), messageId)
-      bus.emit("resolution.recorded", {
-        kind: "ack",
-        sessionKey,
-        channel,
-        chatId,
-        userId,
-        detail: "empty-after-mention",
-      })
-      return
-    }
+
+    const body = (msg.rawText ?? "").trim()
+    const hasBody = body.length > 0
+    const hasImages = !!msg.images?.length
 
     // human-mode:已转人工 → 丢弃(不抢答)
     if (repo.isHumanMode(sessionKey)) {
       // 允许用户在人工模式发「重置」清上下文,但不自动答
-      if (RESET_KEYWORDS.test(msg.rawText)) {
+      if (RESET_KEYWORDS.test(body)) {
         repo.clearResumeId(sessionKey)
         sendText(
           channel,
@@ -124,7 +122,7 @@ export function registerGateway(deps: GatewayDeps): () => void {
     }
 
     // 用户自助重置:清 resumeId,不转 Agent
-    if (RESET_KEYWORDS.test(msg.rawText)) {
+    if (RESET_KEYWORDS.test(body)) {
       repo.clearResumeId(sessionKey)
       sendText(channel, chatId, "已重置对话,我们重新开始吧~", messageId)
       bus.emit("resolution.recorded", {
@@ -138,13 +136,13 @@ export function registerGateway(deps: GatewayDeps): () => void {
     }
 
     // 用法说明
-    if (HELP_KEYWORDS.test(msg.rawText)) {
+    if (HELP_KEYWORDS.test(body)) {
       sendText(channel, chatId, helpText(supportUrl), messageId)
       return
     }
 
     // 转人工：有管理面 → handoff 事件（通知走 adminSurface）；无管理面 → 引导官网
-    if (HANDOFF_KEYWORDS.test(msg.rawText)) {
+    if (HANDOFF_KEYWORDS.test(body)) {
       if (!adminSurface) {
         const link = supportUrl
           ? ` 也可访问 ${supportUrl} 联系支持。`
@@ -159,7 +157,7 @@ export function registerGateway(deps: GatewayDeps): () => void {
       }
       const lastQ =
         repo.listSessions().find((s) => s.key === sessionKey)?.lastQuestion ??
-        msg.rawText
+        body
       bus.emit("handoff.requested", {
         channel,
         sessionKey,
@@ -171,10 +169,54 @@ export function registerGateway(deps: GatewayDeps): () => void {
       return
     }
 
-    // 记录最近问题,供列表预览 / 转人工摘要
-    if (msg.rawText.trim()) {
-      repo.setLastQuestion(sessionKey, msg.rawText.trim())
+    // 加载 @ 前用户近期发言,拼入 qualified text
+    let priorTexts: string[] = []
+    try {
+      const since = repo.priorSince(sessionKey)
+      const rows = repo.recentUserGroupMessages(
+        channel,
+        chatId,
+        userId,
+        PRIOR_USER_CONTEXT_LIMIT,
+        {
+          excludeMessageId: messageId,
+          sinceTs: since,
+        }
+      )
+      priorTexts = clipPriorTexts(
+        rows.map((r) => r.text),
+        PRIOR_CONTEXT_MAX_CHARS,
+        PRIOR_LINE_MAX_CHARS
+      )
+    } catch (err) {
+      bus.emit("error.occurred", {
+        scope: "gateway.prior-context",
+        err,
+        sessionKey,
+        channel,
+        chatId,
+      })
+      priorTexts = []
     }
+
+    // 纯 @ 无正文/图/prior：回用法说明（常见「@ 了但无回复」）
+    if (!hasBody && !hasImages && priorTexts.length === 0) {
+      sendText(channel, chatId, helpText(supportUrl), messageId)
+      bus.emit("resolution.recorded", {
+        kind: "ack",
+        sessionKey,
+        channel,
+        chatId,
+        userId,
+        detail: "empty-after-mention",
+      })
+      return
+    }
+
+    const text = formatPriorContext(priorTexts, body)
+    // 记录最近问题,供列表预览 / 转人工摘要
+    const lastQ = body || priorTexts[priorTexts.length - 1] || ""
+    if (lastQ) repo.setLastQuestion(sessionKey, lastQ)
 
     bus.emit("message.qualified", {
       channel,
@@ -182,7 +224,7 @@ export function registerGateway(deps: GatewayDeps): () => void {
       chatId,
       userId,
       messageId,
-      text: msg.rawText,
+      text,
       images: msg.images,
       quoted: msg.quoted,
       forwarded: msg.forwarded,

--- a/lib/agent/gateway.ts
+++ b/lib/agent/gateway.ts
@@ -8,6 +8,11 @@ import {
   isChatEnabled,
   type ChatRef,
 } from "../channels/enabled-chats"
+import {
+  RESET_KEYWORDS,
+  HANDOFF_KEYWORDS,
+  HELP_KEYWORDS,
+} from "./command-keywords"
 
 export interface GatewayDeps {
   repo: Repo
@@ -24,16 +29,6 @@ export interface GatewayDeps {
   /** 固定支持链接,办不了/人工时附带 */
   supportUrl?: string
 }
-
-// 用户自助重置对话的关键词(整条消息精确匹配,避免误触)
-const RESET_KEYWORDS =
-  /^\s*(重新开始|重置对话|重置会话|重置|\/new|\/reset|\/clear)\s*$/i
-
-// 转人工关键词(整条消息)
-const HANDOFF_KEYWORDS = /^\s*(人工|转人工|人工客服|转接人工|客服)\s*$/i
-
-// 用法说明
-const HELP_KEYWORDS = /^\s*(帮助|怎么用|使用说明|\/help|help)\s*$/i
 
 function helpText(supportUrl?: string): string {
   const link = supportUrl ? `\n官网:${supportUrl}` : ""

--- a/lib/agent/message-buffer.ts
+++ b/lib/agent/message-buffer.ts
@@ -6,6 +6,7 @@ import {
   isChatEnabled,
   type ChatRef,
 } from "../channels/enabled-chats"
+import { isCommandMessage } from "./command-keywords"
 
 export interface MessageBufferDeps {
   repo: Repo
@@ -17,7 +18,7 @@ export interface MessageBufferDeps {
 }
 
 // 旁路缓冲:每条用户群消息落 group_messages,供反思轮询回看。
-// 排除管理面、bot 自己、空文本、非生效会话;不做 @bot 过滤(反思要看全量对话上下文)。
+// 排除管理面、bot 自己、空文本、整句命令、非生效会话;不做 @bot 过滤(反思要看全量对话上下文)。
 export function registerMessageBuffer(deps: MessageBufferDeps): () => void {
   const { repo, botQQ, enabledChats, adminSurface } = deps
   const botId = String(botQQ)
@@ -30,6 +31,8 @@ export function registerMessageBuffer(deps: MessageBufferDeps): () => void {
     // bot 自己:字符串比较(userId 已是 string)
     if (userId === botId) return
     if (!msg.rawText?.trim()) return
+    // 整句命令(重置/帮助/转人工)不入缓冲,避免污染 prior 上下文
+    if (isCommandMessage(msg.rawText)) return
     if (!isChatEnabled(enabledCfg, channel, chatId)) return
     try {
       repo.bufferGroupMessage(

--- a/lib/agent/prior-context.ts
+++ b/lib/agent/prior-context.ts
@@ -1,0 +1,47 @@
+export const PRIOR_USER_CONTEXT_LIMIT = 10
+export const PRIOR_CONTEXT_MAX_CHARS = 2000
+export const PRIOR_LINE_MAX_CHARS = 400
+export const EMPTY_AT_PLACEHOLDER =
+  "（用户仅 @ 了 bot，无新正文；请结合近期发言作答）"
+
+function normalizeLine(text: string, lineMax: number): string {
+  let t = text.trim()
+  if (t.length > lineMax) t = t.slice(0, lineMax - 1) + "…"
+  return t
+    .replace(/\n+/g, "\n")
+    .split("\n")
+    .map((line, i) => (i === 0 ? line : `  ${line}`))
+    .join("\n")
+}
+
+/** texts 已是旧→新；从新到旧纳入直到 maxChars */
+export function clipPriorTexts(
+  texts: string[],
+  maxChars: number,
+  lineMax: number
+): string[] {
+  const kept: string[] = []
+  let used = 0
+  for (let i = texts.length - 1; i >= 0; i--) {
+    const line = normalizeLine(texts[i], lineMax)
+    const cost = line.length + 3 // "- " + newline estimate
+    if (kept.length > 0 && used + cost > maxChars) break
+    if (kept.length === 0 && cost > maxChars) {
+      kept.push(line.slice(0, Math.max(1, maxChars - 1)) + "…")
+      break
+    }
+    kept.push(line)
+    used += cost
+  }
+  return kept.reverse()
+}
+
+export function formatPriorContext(
+  prior: string[],
+  currentBody: string
+): string {
+  if (!prior.length) return currentBody
+  const lines = prior.map((p) => `- ${p}`).join("\n")
+  const cur = currentBody.trim() ? currentBody.trim() : EMPTY_AT_PLACEHOLDER
+  return `【用户近期发言（@前，旧→新）】\n${lines}\n【当前消息】\n${cur}`
+}

--- a/lib/assemble.ts
+++ b/lib/assemble.ts
@@ -99,6 +99,8 @@ export function assemble(deps: AssembleDeps): () => void {
       handoffTimeoutMin: deps.handoffTimeoutMin ?? 30,
       shouldNotify: shouldNotifyHandoff,
     }),
+    // gateway 必须先于 message-buffer 注册:同 tick 内 prior 回看时当前消息尚未入库;
+    // excludeMessageId 是双保险,防止当前触发消息被误纳入 prior。
     registerGateway({
       repo,
       botQQ,

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -336,7 +336,10 @@ function migrateGroupMessages(db: Database.Database): void {
     return
   }
   const cols = tableColumns(db, "group_messages")
-  if (cols.has("channel") && columnType(db, "group_messages", "group_id") === "TEXT") {
+  if (
+    cols.has("channel") &&
+    columnType(db, "group_messages", "group_id") === "TEXT"
+  ) {
     // 已是 v2;确保索引
     db.exec(`
       CREATE UNIQUE INDEX IF NOT EXISTS idx_gm_channel_msg
@@ -632,7 +635,10 @@ function migrateReflectionMeta(db: Database.Database): void {
     return
   }
   // group_id 可能是 INTEGER;有 channel 但 group_id 仍 INTEGER 也重建
-  if (cols.has("channel") && columnType(db, "reflection_meta", "group_id") === "TEXT") {
+  if (
+    cols.has("channel") &&
+    columnType(db, "reflection_meta", "group_id") === "TEXT"
+  ) {
     return
   }
   const hasStatus = cols.has("status")
@@ -691,22 +697,28 @@ function createReflectionMetaV2(db: Database.Database): void {
  */
 export function migrateLegacySessionKeys(db: Database.Database): void {
   if (tableExists(db, "sessions")) {
-    const rows = db
-      .prepare(
-        "SELECT key, session_id, resume_id, human_mode, human_since, last_question, updated_at FROM sessions"
-      )
-      .all() as {
+    // prior_since 为 v3 列:存在则一并迁移,避免 rewrite 时丢纪元
+    const hasPriorSince = tableColumns(db, "sessions").has("prior_since")
+    type SessRow = {
       key: string
       session_id: string | null
       resume_id: string | null
       human_mode: number
       human_since: number | null
       last_question: string | null
+      prior_since?: number | null
       updated_at: number
-    }[]
+    }
+    const rows = db
+      .prepare(
+        hasPriorSince
+          ? "SELECT key, session_id, resume_id, human_mode, human_since, last_question, prior_since, updated_at FROM sessions"
+          : "SELECT key, session_id, resume_id, human_mode, human_since, last_question, updated_at FROM sessions"
+      )
+      .all() as SessRow[]
 
     // 按 canonical key 分组,冲突留 updated_at 最大
-    const best = new Map<string, (typeof rows)[0]>()
+    const best = new Map<string, SessRow>()
     for (const r of rows) {
       const canon = legacySessionKeyToCanonical(r.key)
       const prev = best.get(canon)
@@ -722,28 +734,46 @@ export function migrateLegacySessionKeys(db: Database.Database): void {
     if (needsRewrite) {
       db.exec("DELETE FROM sessions")
       const ins = db.prepare(
-        `INSERT INTO sessions
-          (key, session_id, resume_id, human_mode, human_since, last_question, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`
+        hasPriorSince
+          ? `INSERT INTO sessions
+              (key, session_id, resume_id, human_mode, human_since, last_question, prior_since, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+          : `INSERT INTO sessions
+              (key, session_id, resume_id, human_mode, human_since, last_question, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?)`
       )
       for (const r of best.values()) {
-        ins.run(
-          r.key,
-          r.session_id,
-          r.resume_id,
-          r.human_mode,
-          r.human_since,
-          r.last_question,
-          r.updated_at
-        )
+        if (hasPriorSince) {
+          ins.run(
+            r.key,
+            r.session_id,
+            r.resume_id,
+            r.human_mode,
+            r.human_since,
+            r.last_question,
+            r.prior_since ?? null,
+            r.updated_at
+          )
+        } else {
+          ins.run(
+            r.key,
+            r.session_id,
+            r.resume_id,
+            r.human_mode,
+            r.human_since,
+            r.last_question,
+            r.updated_at
+          )
+        }
       }
     }
   }
 
   if (tableExists(db, "tickets")) {
-    const tickets = db
-      .prepare("SELECT id, session_key FROM tickets")
-      .all() as { id: number; session_key: string }[]
+    const tickets = db.prepare("SELECT id, session_key FROM tickets").all() as {
+      id: number
+      session_key: string
+    }[]
     const upd = db.prepare("UPDATE tickets SET session_key = ? WHERE id = ?")
     for (const t of tickets) {
       const next = legacySessionKeyToCanonical(t.session_key)

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -61,6 +61,33 @@ function migrate(db: Database.Database, dim: number): void {
     // 已是 v2:幂等确保表结构(防空库误标 version 等极端情况)
     createV2Tables(db, dim)
   }
+
+  // v3: sessions.prior_since + 用户消息 lookback 索引(幂等)
+  if (userVersion(db) < 3) {
+    ensureSessionsPriorSince(db)
+    ensureGmUserTimeIndex(db)
+    setUserVersion(db, 3)
+  } else {
+    ensureSessionsPriorSince(db)
+    ensureGmUserTimeIndex(db)
+  }
+}
+
+/** v3: sessions 补 prior_since 列(已存在则跳过) */
+function ensureSessionsPriorSince(db: Database.Database): void {
+  if (!tableExists(db, "sessions")) return
+  if (!tableColumns(db, "sessions").has("prior_since")) {
+    db.exec("ALTER TABLE sessions ADD COLUMN prior_since INTEGER")
+  }
+}
+
+/** v3: group_messages 用户 lookback 复合索引 */
+function ensureGmUserTimeIndex(db: Database.Database): void {
+  if (!tableExists(db, "group_messages")) return
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_gm_channel_group_user_time
+      ON group_messages(channel, group_id, user_id, created_at, id)
+  `)
 }
 
 /** v1 基线表(升级前源形态)。全新库也会先建这套再 migrateToV2。 */
@@ -73,6 +100,7 @@ function createV1Tables(db: Database.Database, dim: number): void {
       human_mode INTEGER NOT NULL DEFAULT 0,
       human_since INTEGER,
       last_question TEXT,
+      prior_since INTEGER,
       updated_at INTEGER NOT NULL DEFAULT (unixepoch('subsec') * 1000)
     );
     CREATE TABLE IF NOT EXISTS seen_messages (
@@ -773,6 +801,7 @@ function createV2Tables(db: Database.Database, dim: number): void {
       human_mode INTEGER NOT NULL DEFAULT 0,
       human_since INTEGER,
       last_question TEXT,
+      prior_since INTEGER,
       updated_at INTEGER NOT NULL DEFAULT (unixepoch('subsec') * 1000)
     );
     CREATE TABLE IF NOT EXISTS seen_messages (

--- a/lib/db/repo.ts
+++ b/lib/db/repo.ts
@@ -78,15 +78,19 @@ export class Repo {
   // 返回受影响(此前仍有 resume_id)的会话数,供后台提示。
   // 同时推进全部行的 prior_since 纪元(含本已无 resume 的行)。
   clearAllResumeIds(): number {
-    const info = this.db
-      .prepare(
-        "UPDATE sessions SET resume_id = NULL, updated_at = unixepoch('subsec')*1000 WHERE resume_id IS NOT NULL"
-      )
-      .run()
-    this.db
-      .prepare("UPDATE sessions SET prior_since = unixepoch('subsec')*1000")
-      .run()
-    return info.changes
+    return this.transaction(() => {
+      const info = this.db
+        .prepare(
+          "UPDATE sessions SET resume_id = NULL, updated_at = unixepoch('subsec')*1000 WHERE resume_id IS NOT NULL"
+        )
+        .run()
+      this.db
+        .prepare(
+          "UPDATE sessions SET prior_since = unixepoch('subsec')*1000, updated_at = unixepoch('subsec')*1000"
+        )
+        .run()
+      return info.changes
+    })
   }
 
   getSessionId(key: string): string | undefined {
@@ -190,6 +194,7 @@ export class Repo {
     messageId: string | null
     id: number
   }[] {
+    if (limit <= 0) return []
     const sinceTs = opts?.sinceTs ?? 0
     const exclude = opts?.excludeMessageId
     const rows = this.db

--- a/lib/db/repo.ts
+++ b/lib/db/repo.ts
@@ -59,22 +59,32 @@ export class Repo {
       .run(key, sessionId, sessionId)
   }
 
-  // 仅清 resume_id → 下条消息开全新 SDK session;保留 session_id 供网页仍能查看历史
+  // 仅清 resume_id → 下条消息开全新 SDK session;保留 session_id 供网页仍能查看历史。
+  // 同时推进 prior_since 纪元:此后 recentUserGroupMessages 不再回看边界前消息。
   clearResumeId(key: string): void {
     this.db
       .prepare(
-        "UPDATE sessions SET resume_id = NULL, updated_at = unixepoch('subsec')*1000 WHERE key = ?"
+        `INSERT INTO sessions (key, resume_id, prior_since, updated_at)
+         VALUES (?, NULL, unixepoch('subsec')*1000, unixepoch('subsec')*1000)
+         ON CONFLICT(key) DO UPDATE SET
+           resume_id = NULL,
+           prior_since = unixepoch('subsec')*1000,
+           updated_at = unixepoch('subsec')*1000`
       )
       .run(key)
   }
 
   // 一键清所有会话的 resume_id → 每个会话下条消息各自开全新对话;session_id 保留,网页历史仍可查。
   // 返回受影响(此前仍有 resume_id)的会话数,供后台提示。
+  // 同时推进全部行的 prior_since 纪元(含本已无 resume 的行)。
   clearAllResumeIds(): number {
     const info = this.db
       .prepare(
         "UPDATE sessions SET resume_id = NULL, updated_at = unixepoch('subsec')*1000 WHERE resume_id IS NOT NULL"
       )
+      .run()
+    this.db
+      .prepare("UPDATE sessions SET prior_since = unixepoch('subsec')*1000")
       .run()
     return info.changes
   }
@@ -86,6 +96,14 @@ export class Repo {
     return row?.session_id ?? undefined
   }
 
+  // 该会话 prior 上下文上界:clearResumeId 后推进;未设则为 0(无过滤)
+  priorSince(key: string): number {
+    const row = this.db
+      .prepare("SELECT prior_since FROM sessions WHERE key = ?")
+      .get(key) as { prior_since: number | null } | undefined
+    return row?.prior_since ?? 0
+  }
+
   // 续接指针:reset 后为空 → Agent 不 resume,开新会话。
   // maxIdleMs > 0 时惰性过期:距上次活动(updated_at)超时则视为无 resume,下条消息开新会话
   // (不改库,session_id 仍在 → 网页可查历史);maxIdleMs <= 0 关闭过期。
@@ -95,7 +113,8 @@ export class Repo {
         `SELECT resume_id FROM sessions
          WHERE key = ? AND (? <= 0 OR updated_at >= unixepoch('subsec') * 1000 - ?)`
       )
-      .get(key, maxIdleMs, maxIdleMs) as { resume_id: string | null } | undefined
+      .get(key, maxIdleMs, maxIdleMs) as
+      { resume_id: string | null } | undefined
     return row?.resume_id ?? undefined
   }
 
@@ -154,6 +173,57 @@ export class Repo {
         "INSERT OR IGNORE INTO group_messages (channel, group_id, user_id, sender_role, text, message_id) VALUES (?, ?, ?, ?, ?, ?)"
       )
       .run(channel, chatId, userId, senderRole, text, messageId ?? null)
+  }
+
+  // 某用户在某群的最近非空消息(@ 前 prior 上下文用)。
+  // 先 DESC 取 limit,再 reverse 为升序;同 created_at 按 id 稳定排序。
+  // opts.sinceTs: 仅 created_at > sinceTs(通常取 priorSince);opts.excludeMessageId: 排除当前触发消息。
+  recentUserGroupMessages(
+    channel: string,
+    chatId: string,
+    userId: string,
+    limit: number,
+    opts?: { excludeMessageId?: string; sinceTs?: number }
+  ): {
+    text: string
+    createdAt: number
+    messageId: string | null
+    id: number
+  }[] {
+    const sinceTs = opts?.sinceTs ?? 0
+    const exclude = opts?.excludeMessageId
+    const rows = this.db
+      .prepare(
+        `SELECT id, text, created_at, message_id FROM group_messages
+         WHERE channel = ? AND group_id = ? AND user_id = ?
+           AND length(trim(text)) > 0
+           AND created_at > ?
+           AND (? IS NULL OR message_id IS NULL OR message_id != ?)
+         ORDER BY created_at DESC, id DESC
+         LIMIT ?`
+      )
+      .all(
+        channel,
+        chatId,
+        userId,
+        sinceTs,
+        exclude ?? null,
+        exclude ?? null,
+        limit
+      ) as {
+      id: number
+      text: string
+      created_at: number
+      message_id: string | null
+    }[]
+    return rows
+      .map((r) => ({
+        text: r.text,
+        createdAt: r.created_at,
+        messageId: r.message_id,
+        id: r.id,
+      }))
+      .reverse()
   }
 
   // 上界 untilTs 前存在 owner/admin 发言的候选 chat,去重(每群游标另判 band)
@@ -517,9 +587,7 @@ export class Repo {
 
   // 每 chat 问题排行游标(config key = topic_cursor:{channel}:{chatId})
   topicCursor(channel: string, chatId: string): number {
-    return Number(
-      this.getConfigRow(`topic_cursor:${channel}:${chatId}`) ?? "0"
-    )
+    return Number(this.getConfigRow(`topic_cursor:${channel}:${chatId}`) ?? "0")
   }
 
   setTopicCursor(channel: string, chatId: string, ts: number): void {
@@ -563,9 +631,7 @@ export class Repo {
   // 生效 chat 中 topic 游标的最小值(忽略从未处理过的 0,避免恒卡 prune)。
   // 无任何 >0 游标 → MAX_SAFE_INTEGER(prune 不受 topic 侧约束)。
   // 接受 {channel, chatId}[] 或历史 number[](视为 qq 群号,Phase 0 兼容)。
-  minTopicCursor(
-    enabled: ChatRef[] | number[] | string[]
-  ): number {
+  minTopicCursor(enabled: ChatRef[] | number[] | string[]): number {
     let min = Number.MAX_SAFE_INTEGER
     for (const g of enabled) {
       let channel: string
@@ -614,7 +680,9 @@ export class Repo {
   // 每 chat 反思游标(config key = reflect_cursor:{channel}:{chatId})
   reflectCursors(): { channel: string; chatId: string; cursor: number }[] {
     const rows = this.db
-      .prepare("SELECT key, value FROM config WHERE key LIKE 'reflect_cursor:%'")
+      .prepare(
+        "SELECT key, value FROM config WHERE key LIKE 'reflect_cursor:%'"
+      )
       .all() as { key: string; value: string }[]
     const out: { channel: string; chatId: string; cursor: number }[] = []
     for (const r of rows) {
@@ -732,9 +800,11 @@ export class Repo {
   }
 
   // 升格为正式文档:标 promoted;写文件+向量入库由 applyPromote / API 处理
-  promoteReflection(
-    chunkId: number
-  ): { ok: boolean; content?: string; status?: ReflectionStatus } {
+  promoteReflection(chunkId: number): {
+    ok: boolean
+    content?: string
+    status?: ReflectionStatus
+  } {
     const row = this.db
       .prepare(
         "SELECT content FROM kb_chunks WHERE id = ? AND doc = 'human-reflection'"
@@ -827,9 +897,7 @@ export class Repo {
     return info.changes
   }
 
-  getTicket(
-    id: number
-  ):
+  getTicket(id: number):
     | {
         id: number
         sessionKey: string
@@ -1022,13 +1090,15 @@ export class Repo {
   deleteKbDoc(doc: string): number {
     return this.db.transaction(() => {
       const ids = (
-        this.db
-          .prepare("SELECT id FROM kb_chunks WHERE doc = ?")
-          .all(doc) as { id: number }[]
+        this.db.prepare("SELECT id FROM kb_chunks WHERE doc = ?").all(doc) as {
+          id: number
+        }[]
       ).map((r) => r.id)
       if (!ids.length) return 0
       const ph = ids.map(() => "?").join(",")
-      this.db.prepare(`DELETE FROM kb_vec WHERE chunk_id IN (${ph})`).run(...ids)
+      this.db
+        .prepare(`DELETE FROM kb_vec WHERE chunk_id IN (${ph})`)
+        .run(...ids)
       const info = this.db
         .prepare(`DELETE FROM kb_chunks WHERE id IN (${ph})`)
         .run(...ids)
@@ -1150,9 +1220,9 @@ export class Repo {
   }
 
   countSessions(): number {
-    const row = this.db
-      .prepare("SELECT COUNT(*) AS n FROM sessions")
-      .get() as { n: number }
+    const row = this.db.prepare("SELECT COUNT(*) AS n FROM sessions").get() as {
+      n: number
+    }
     return row.n
   }
 

--- a/tests/lib/agent/gateway.test.ts
+++ b/tests/lib/agent/gateway.test.ts
@@ -384,4 +384,103 @@ describe("gateway", () => {
     expect(h.sessionKey).toBe(sk)
     expect(h.by).toBe("admin")
   })
+
+  function seedPrior(texts: string[]) {
+    for (let i = 0; i < texts.length; i++) {
+      repo.bufferGroupMessage("qq", "1", "2", "member", texts[i], `p${i}`)
+    }
+  }
+
+  it("纯 @ 有 prior → qualified 含历史,不发用法说明", async () => {
+    seedPrior(["刚才的订单号是 ABC"])
+    const qualified = collectQualified()
+    const send = vi.fn()
+    bus.on("action.send", send)
+    bus.emit(
+      "message.received",
+      qqMsg({ messageId: "p-empty", rawText: "", atList: [BOT] })
+    )
+    const q = await qualified
+    expect(q.text).toContain("刚才的订单号是 ABC")
+    expect(q.text).toContain("【用户近期发言")
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it("空白 @ 无 prior → 用法说明", async () => {
+    const qualified = vi.fn()
+    bus.on("message.qualified", qualified)
+    const p = new Promise<any>((res) => bus.once("action.send", res))
+    bus.emit(
+      "message.received",
+      qqMsg({ messageId: "p-blank", rawText: "  \n\t", atList: [BOT] })
+    )
+    const a = await p
+    expect(a.text).toContain("@我")
+    expect(qualified).not.toHaveBeenCalled()
+  })
+
+  it("有 prior + 短正文 → text 含历史与正文", async () => {
+    seedPrior(["背景信息"])
+    const p = collectQualified()
+    bus.emit(
+      "message.received",
+      qqMsg({ messageId: "p-body", rawText: "帮我看看", atList: [BOT] })
+    )
+    const q = await p
+    expect(q.text).toContain("背景信息")
+    expect(q.text).toContain("帮我看看")
+    expect(q.text).toContain("【当前消息】")
+  })
+
+  it("重置后 prior 隔离:纯 @ 回用法说明,不 qualified", async () => {
+    seedPrior(["旧问题"])
+    // 先重置推进 prior_since
+    const resetP = new Promise<any>((res) => bus.once("action.send", res))
+    bus.emit(
+      "message.received",
+      qqMsg({ messageId: "p-reset", rawText: "重置", atList: [BOT] })
+    )
+    await resetP
+
+    const qualified = vi.fn()
+    bus.on("message.qualified", qualified)
+    const helpP = new Promise<any>((res) => bus.once("action.send", res))
+    bus.emit(
+      "message.received",
+      qqMsg({ messageId: "p-after-reset", rawText: "", atList: [BOT] })
+    )
+    const a = await helpP
+    expect(a.text).toContain("@我")
+    expect(qualified).not.toHaveBeenCalled()
+  })
+
+  it("recentUserGroupMessages 抛错 → 有正文仍 qualified,并 error.occurred", async () => {
+    vi.spyOn(repo, "recentUserGroupMessages").mockImplementation(() => {
+      throw new Error("db down")
+    })
+    const errP = new Promise<any>((res) => bus.once("error.occurred", res))
+    const qP = collectQualified()
+    bus.emit(
+      "message.received",
+      qqMsg({ messageId: "p-err", rawText: "还在吗", atList: [BOT] })
+    )
+    const [err, q] = await Promise.all([errP, qP])
+    expect(q.text).toBe("还在吗")
+    expect(err.scope).toBe("gateway.prior-context")
+    expect(err.sessionKey).toBe(SK)
+    expect(err.channel).toBe("qq")
+    expect(err.chatId).toBe("1")
+  })
+
+  it("纯 @ 有 prior → lastQuestion 用 prior 末条", async () => {
+    seedPrior(["第一条", "末条问题"])
+    const p = collectQualified()
+    bus.emit(
+      "message.received",
+      qqMsg({ messageId: "p-lq", rawText: "", atList: [BOT] })
+    )
+    await p
+    const s = repo.listSessions().find((x) => x.key === SK)
+    expect(s?.lastQuestion).toBe("末条问题")
+  })
 })

--- a/tests/lib/agent/message-buffer.test.ts
+++ b/tests/lib/agent/message-buffer.test.ts
@@ -133,4 +133,19 @@ describe("message-buffer", () => {
     expect(win[0].text).toBe("tg 消息")
     stop()
   })
+
+  it("重置/帮助/转人工整句不缓冲", () => {
+    const stop = registerMessageBuffer({
+      repo,
+      botQQ: 1,
+      adminSurface: { channel: "qq" as const, chatId: "999" },
+      enabledChats: [{ channel: "qq" as const, chatId: "100" }],
+    })
+    for (const rawText of ["重置", "帮助", "人工", "怎么充值"]) {
+      bus.emit("message.received", msg({ rawText, messageId: rawText }))
+    }
+    const win = repo.groupMessageWindow("qq", "100", 0, 10)
+    expect(win.map((w) => w.text)).toEqual(["怎么充值"])
+    stop()
+  })
 })

--- a/tests/lib/agent/prior-context.test.ts
+++ b/tests/lib/agent/prior-context.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest"
+import {
+  PRIOR_LINE_MAX_CHARS,
+  EMPTY_AT_PLACEHOLDER,
+  clipPriorTexts,
+  formatPriorContext,
+} from "@/lib/agent/prior-context"
+
+describe("formatPriorContext", () => {
+  it("无 prior 时原样返回 body", () => {
+    expect(formatPriorContext([], "你好")).toBe("你好")
+  })
+
+  it("有 prior + body 时拼出近期发言与当前消息", () => {
+    const out = formatPriorContext(["旧话", "新话"], "当前")
+    expect(out).toBe(
+      "【用户近期发言（@前，旧→新）】\n- 旧话\n- 新话\n【当前消息】\n当前"
+    )
+  })
+
+  it("有 prior 且 body 为空时用 EMPTY_AT_PLACEHOLDER", () => {
+    const out = formatPriorContext(["之前说的"], "   ")
+    expect(out).toContain(EMPTY_AT_PLACEHOLDER)
+    expect(out).toBe(
+      `【用户近期发言（@前，旧→新）】\n- 之前说的\n【当前消息】\n${EMPTY_AT_PLACEHOLDER}`
+    )
+  })
+
+  it("多行经 clip 再 format 时续行有两空格缩进", () => {
+    const clipped = clipPriorTexts(["第一行\n第二行"], 2000, PRIOR_LINE_MAX_CHARS)
+    expect(clipped).toEqual(["第一行\n  第二行"])
+    const out = formatPriorContext(clipped, "当前")
+    expect(out).toContain("- 第一行\n  第二行")
+  })
+})
+
+describe("clipPriorTexts", () => {
+  it("单行超过 PRIOR_LINE_MAX_CHARS 时以 … 结尾", () => {
+    const long = "甲".repeat(PRIOR_LINE_MAX_CHARS + 50)
+    const [line] = clipPriorTexts([long], 10_000, PRIOR_LINE_MAX_CHARS)
+    expect(line.endsWith("…")).toBe(true)
+    expect(line.length).toBe(PRIOR_LINE_MAX_CHARS)
+  })
+
+  it("字符预算优先保留较新消息", () => {
+    // 每条约 11 字符 + 3 开销 ≈ 14；预算 30 只够装最新两条
+    const texts = ["旧消息AAAAAAAA", "中消息BBBBBBBB", "新消息CCCCCCCC"]
+    const kept = clipPriorTexts(texts, 30, PRIOR_LINE_MAX_CHARS)
+    expect(kept).toEqual(["中消息BBBBBBBB", "新消息CCCCCCCC"])
+    expect(kept).not.toContain("旧消息AAAAAAAA")
+  })
+})

--- a/tests/lib/db/repo.test.ts
+++ b/tests/lib/db/repo.test.ts
@@ -619,6 +619,83 @@ describe("ranking repo 聚合", () => {
   })
 })
 
+describe("prior_since schema migration", () => {
+  it("全新 openDb 有 prior_since 且 user_version >= 3", () => {
+    const d = openDb(":memory:", 3)
+    const cols = (
+      d.prepare("PRAGMA table_info(sessions)").all() as { name: string }[]
+    ).map((c) => c.name)
+    expect(cols).toContain("prior_since")
+    expect(d.pragma("user_version", { simple: true }) as number).toBeGreaterThanOrEqual(
+      3
+    )
+    d.close()
+  })
+
+  it("磁盘 v2 库无 prior_since 时 openDb 升级补列并升到 user_version >= 3", () => {
+    const dir = mkdtempSync(join(tmpdir(), "prayer-v3-"))
+    const p = join(dir, "v2.db")
+    // 手工造最小 v2 形态:sessions 无 prior_since,user_version=2
+    const raw = new BetterSqlite3(p)
+    raw.exec(`
+      CREATE TABLE sessions (
+        key TEXT PRIMARY KEY,
+        session_id TEXT,
+        resume_id TEXT,
+        human_mode INTEGER NOT NULL DEFAULT 0,
+        human_since INTEGER,
+        last_question TEXT,
+        updated_at INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE TABLE group_messages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        channel TEXT NOT NULL DEFAULT 'qq',
+        group_id TEXT NOT NULL,
+        user_id TEXT NOT NULL,
+        sender_role TEXT,
+        text TEXT NOT NULL,
+        message_id TEXT,
+        created_at INTEGER NOT NULL DEFAULT 0
+      );
+    `)
+    raw.pragma("user_version = 2")
+    raw.prepare(
+      "INSERT INTO sessions (key, session_id, updated_at) VALUES (?, ?, ?)"
+    ).run("qq:1:2", "sid", 100)
+    raw.close()
+
+    // 升级路径必须走 openDb(加载 sqlite-vec + migrate)
+    const upgraded = openDb(p, 3)
+    const cols = (
+      upgraded.prepare("PRAGMA table_info(sessions)").all() as {
+        name: string
+      }[]
+    ).map((c) => c.name)
+    expect(cols).toContain("prior_since")
+    expect(
+      upgraded.pragma("user_version", { simple: true }) as number
+    ).toBeGreaterThanOrEqual(3)
+    // 原数据保留
+    const row = upgraded
+      .prepare("SELECT key, session_id, prior_since FROM sessions")
+      .get() as { key: string; session_id: string; prior_since: number | null }
+    expect(row).toEqual({
+      key: "qq:1:2",
+      session_id: "sid",
+      prior_since: null,
+    })
+    // 用户 lookback 复合索引已建
+    const idx = upgraded
+      .prepare(
+        "SELECT 1 AS ok FROM sqlite_master WHERE type='index' AND name='idx_gm_channel_group_user_time'"
+      )
+      .get() as { ok: number } | undefined
+    expect(idx?.ok).toBe(1)
+    upgraded.close()
+    rmSync(dir, { recursive: true, force: true })
+  })
+})
+
 describe("channel schema migration", () => {
   it("group_messages 支持 channel 与复合唯一", () => {
     const r = new Repo(openDb(":memory:", 3))
@@ -748,9 +825,10 @@ describe("channel schema migration", () => {
     raw.close()
 
     const migrated = openDb(p, 3)
+    // v1→v2→v3 一路升完
     expect(
       (migrated.pragma("user_version", { simple: true }) as number)
-    ).toBe(2)
+    ).toBe(3)
     const sk = migrated
       .prepare("SELECT key FROM sessions")
       .get() as { key: string }
@@ -790,7 +868,7 @@ describe("channel schema migration", () => {
     // 幂等:再 open 不炸
     migrated.close()
     const again = openDb(p, 3)
-    expect(again.pragma("user_version", { simple: true })).toBe(2)
+    expect(again.pragma("user_version", { simple: true })).toBe(3)
     again.close()
     rmSync(dir, { recursive: true, force: true })
   })

--- a/tests/lib/db/repo.test.ts
+++ b/tests/lib/db/repo.test.ts
@@ -145,10 +145,9 @@ describe("Repo tickets", () => {
   it("listTickets 含 open 与 closed,按创建时间降序", () => {
     const a = repo.createTicket("g:1", "问题A")
     const b = repo.createTicket("g:2", "问题B")
-    db.prepare("UPDATE tickets SET status='closed', created_at=? WHERE id=?").run(
-      1000,
-      a
-    )
+    db.prepare(
+      "UPDATE tickets SET status='closed', created_at=? WHERE id=?"
+    ).run(1000, a)
     db.prepare("UPDATE tickets SET created_at=? WHERE id=?").run(2000, b)
     const list = repo.listTickets()
     expect(list.length).toBe(2)
@@ -255,9 +254,7 @@ describe("group_messages 迁移去重", () => {
 
     const migrated = openDb(p, 3)
     const kept = migrated
-      .prepare(
-        "SELECT created_at FROM group_messages WHERE message_id = '42'"
-      )
+      .prepare("SELECT created_at FROM group_messages WHERE message_id = '42'")
       .all() as { created_at: number }[]
     expect(kept).toEqual([{ created_at: 1000 }]) // 只留最早一份
     const nulls = migrated
@@ -483,12 +480,7 @@ describe("repo 主动兜底支持", () => {
 
   it("groupMemberMessagesBetween:只取(after,until]内非管理发言,升序", () => {
     const r = mk()
-    const seed = (
-      uid: string,
-      role: string | null,
-      text: string,
-      at: number
-    ) =>
+    const seed = (uid: string, role: string | null, text: string, at: number) =>
       (r as any).db
         .prepare(
           "INSERT INTO group_messages (channel,group_id,user_id,sender_role,text,created_at) VALUES (?,?,?,?,?,?)"
@@ -510,7 +502,9 @@ describe("repo 主动兜底支持", () => {
     r.bufferGroupMessage("qq", "100", "200", "member", "带 id", "8001")
     r.bufferGroupMessage("qq", "100", "201", "member", "无 id") // 缺省
     const rows = r.groupMemberMessagesBetween("qq", "100", 0, Date.now() + 1000)
-    const byUser = Object.fromEntries(rows.map((row) => [row.userId, row.messageId]))
+    const byUser = Object.fromEntries(
+      rows.map((row) => [row.userId, row.messageId])
+    )
     expect(byUser["200"]).toBe("8001")
     expect(byUser["201"]).toBeNull()
   })
@@ -601,10 +595,7 @@ describe("ranking repo 聚合", () => {
     r.insertQuestionOccurrence(a, "qq", "100", "3", "超时会重复扣费吗", 3000)
     expect(r.rankingByWindow(0)[0].count).toBe(3) // 计数含重复
     // 样例去重 → 只两条,最近的重复句取 max ts 排前
-    expect(r.topicSamples(a, 5)).toEqual([
-      "超时会重复扣费吗",
-      "任务超时怎么办",
-    ])
+    expect(r.topicSamples(a, 5)).toEqual(["超时会重复扣费吗", "任务超时怎么办"])
   })
 
   it("rankingByWindow count 相同按 lastTs DESC", () => {
@@ -626,9 +617,9 @@ describe("prior_since schema migration", () => {
       d.prepare("PRAGMA table_info(sessions)").all() as { name: string }[]
     ).map((c) => c.name)
     expect(cols).toContain("prior_since")
-    expect(d.pragma("user_version", { simple: true }) as number).toBeGreaterThanOrEqual(
-      3
-    )
+    expect(
+      d.pragma("user_version", { simple: true }) as number
+    ).toBeGreaterThanOrEqual(3)
     d.close()
   })
 
@@ -659,9 +650,11 @@ describe("prior_since schema migration", () => {
       );
     `)
     raw.pragma("user_version = 2")
-    raw.prepare(
-      "INSERT INTO sessions (key, session_id, updated_at) VALUES (?, ?, ?)"
-    ).run("qq:1:2", "sid", 100)
+    raw
+      .prepare(
+        "INSERT INTO sessions (key, session_id, updated_at) VALUES (?, ?, ?)"
+      )
+      .run("qq:1:2", "sid", 100)
     raw.close()
 
     // 升级路径必须走 openDb(加载 sqlite-vec + migrate)
@@ -734,9 +727,10 @@ describe("channel schema migration", () => {
     d.prepare(
       "INSERT INTO sessions (key, session_id, updated_at) VALUES (?, ?, ?)"
     ).run("qq:123:456", "sid-new", 2000) // 冲突:保留较新
-    d.prepare(
-      "INSERT INTO tickets (session_key, summary) VALUES (?, ?)"
-    ).run("789:101", "旧工单")
+    d.prepare("INSERT INTO tickets (session_key, summary) VALUES (?, ?)").run(
+      "789:101",
+      "旧工单"
+    )
     d.prepare(
       "INSERT INTO config (key, value, updated_at) VALUES (?, ?, ?)"
     ).run("reflect_cursor:42", "999", 1000)
@@ -810,28 +804,30 @@ describe("channel schema migration", () => {
         created_at INTEGER NOT NULL DEFAULT 0
       );
     `)
-    raw.prepare(
-      "INSERT INTO sessions (key, session_id, updated_at) VALUES (?, ?, ?)"
-    ).run("100:200", "s1", 50)
-    raw.prepare(
-      "INSERT INTO config (key, value, updated_at) VALUES (?, ?, ?)"
-    ).run("reflect_cursor:100", "12345", 1)
-    raw.prepare(
-      "INSERT INTO group_messages (group_id,user_id,sender_role,text,message_id,created_at) VALUES (?,?,?,?,?,?)"
-    ).run(100, 200, "member", "hi", 9, 10)
-    raw.prepare(
-      "INSERT INTO tickets (session_key, summary) VALUES (?, ?)"
-    ).run("100:200", "t1")
+    raw
+      .prepare(
+        "INSERT INTO sessions (key, session_id, updated_at) VALUES (?, ?, ?)"
+      )
+      .run("100:200", "s1", 50)
+    raw
+      .prepare("INSERT INTO config (key, value, updated_at) VALUES (?, ?, ?)")
+      .run("reflect_cursor:100", "12345", 1)
+    raw
+      .prepare(
+        "INSERT INTO group_messages (group_id,user_id,sender_role,text,message_id,created_at) VALUES (?,?,?,?,?,?)"
+      )
+      .run(100, 200, "member", "hi", 9, 10)
+    raw
+      .prepare("INSERT INTO tickets (session_key, summary) VALUES (?, ?)")
+      .run("100:200", "t1")
     raw.close()
 
     const migrated = openDb(p, 3)
     // v1→v2→v3 一路升完
-    expect(
-      (migrated.pragma("user_version", { simple: true }) as number)
-    ).toBe(3)
-    const sk = migrated
-      .prepare("SELECT key FROM sessions")
-      .get() as { key: string }
+    expect(migrated.pragma("user_version", { simple: true }) as number).toBe(3)
+    const sk = migrated.prepare("SELECT key FROM sessions").get() as {
+      key: string
+    }
     expect(sk.key).toBe("qq:100:200")
     const cur = migrated
       .prepare("SELECT key, value FROM config WHERE key LIKE 'reflect_cursor%'")
@@ -861,9 +857,9 @@ describe("channel schema migration", () => {
     ).map((c) => c.name)
     expect(seenCols).toContain("dedupe_key")
     expect(seenCols).not.toContain("message_id")
-    const tk = migrated
-      .prepare("SELECT session_key FROM tickets")
-      .get() as { session_key: string }
+    const tk = migrated.prepare("SELECT session_key FROM tickets").get() as {
+      session_key: string
+    }
     expect(tk.session_key).toBe("qq:100:200")
     // 幂等:再 open 不炸
     migrated.close()
@@ -871,5 +867,55 @@ describe("channel schema migration", () => {
     expect(again.pragma("user_version", { simple: true })).toBe(3)
     again.close()
     rmSync(dir, { recursive: true, force: true })
+  })
+})
+
+describe("Repo prior context", () => {
+  it("clearResumeId 推进 prior_since；边界前消息不可见", () => {
+    repo.bufferGroupMessage("qq", "1", "2", "member", "旧问题", "m1")
+    const before = Date.now()
+    repo.setSessionId("qq:1:2", "sid")
+    repo.clearResumeId("qq:1:2")
+    const since = repo.priorSince("qq:1:2")
+    expect(since).toBeGreaterThanOrEqual(before)
+    const rows = repo.recentUserGroupMessages("qq", "1", "2", 10, {
+      sinceTs: since,
+    })
+    expect(rows).toHaveLength(0)
+  })
+
+  it("recentUserGroupMessages 只返回该用户非空、升序、exclude、limit", () => {
+    repo.bufferGroupMessage("qq", "1", "2", null, "a", "1")
+    repo.bufferGroupMessage("qq", "1", "2", null, "b", "2")
+    repo.bufferGroupMessage("qq", "1", "9", null, "他人", "3")
+    // empty text via SQL if buffer rejects
+    db.prepare(
+      `INSERT INTO group_messages (channel, group_id, user_id, text, message_id)
+       VALUES ('qq','1','2','   ','4')`
+    ).run()
+    const rows = repo.recentUserGroupMessages("qq", "1", "2", 10, {
+      excludeMessageId: "2",
+    })
+    expect(rows.map((r) => r.text)).toEqual(["a"])
+  })
+
+  it("同 created_at 按 id 升序稳定", () => {
+    const t = Date.now()
+    db.prepare(
+      `INSERT INTO group_messages (channel, group_id, user_id, text, message_id, created_at)
+       VALUES ('qq','1','2','x','10',?), ('qq','1','2','y','11',?)`
+    ).run(t, t)
+    const rows = repo.recentUserGroupMessages("qq", "1", "2", 10)
+    expect(rows.map((r) => r.text)).toEqual(["x", "y"])
+  })
+
+  it("clearAllResumeIds 推进全部行 prior_since，返回值仍只计有 resume 的", () => {
+    repo.setSessionId("qq:1:a", "s1")
+    repo.setSessionId("qq:1:b", "s2")
+    repo.clearResumeId("qq:1:b")
+    const n = repo.clearAllResumeIds()
+    expect(n).toBe(1)
+    expect(repo.priorSince("qq:1:a")).toBeGreaterThan(0)
+    expect(repo.priorSince("qq:1:b")).toBeGreaterThan(0)
   })
 })

--- a/tests/lib/db/repo.test.ts
+++ b/tests/lib/db/repo.test.ts
@@ -918,4 +918,14 @@ describe("Repo prior context", () => {
     expect(repo.priorSince("qq:1:a")).toBeGreaterThan(0)
     expect(repo.priorSince("qq:1:b")).toBeGreaterThan(0)
   })
+
+  it("priorSince 缺失 key 返回 0", () => {
+    expect(repo.priorSince("qq:no:such")).toBe(0)
+  })
+
+  it("recentUserGroupMessages limit<=0 返回空数组", () => {
+    repo.bufferGroupMessage("qq", "1", "2", null, "a", "1")
+    expect(repo.recentUserGroupMessages("qq", "1", "2", 0)).toEqual([])
+    expect(repo.recentUserGroupMessages("qq", "1", "2", -1)).toEqual([])
+  })
 })


### PR DESCRIPTION
## Summary

- 用户被 `@` 时，从 `group_messages` 拉取该用户在 `prior_since` 纪元内最多 10 条近期发言，拼进 agent prompt，覆盖「先提问再 @」与「@ + 短补充」。
- 新增 `sessions.prior_since`（DB v3）与 `recentUserGroupMessages`；重置 / 一键清会话会推进纪元。
- 命令句（重置/帮助/转人工）共享关键词且不入缓冲，避免重置后污染 prior；字符预算与查库失败降级。

## Spec / Plan

- `docs/superpowers/specs/2026-07-20-at-prior-context-design.md`
- `docs/superpowers/plans/2026-07-20-at-prior-context.md`

## Test Plan

- [x] `pnpm typecheck`
- [x] `pnpm test`（589 tests）
- [x] 相关单测：gateway prior / prior-context / message-buffer 命令跳过 / repo 迁移与纪元
- [ ] 线上群：先发问题再纯 `@Bot`，应进 agent 而非只回用法说明
- [ ] 发「重置」后再纯 `@`，不应带上重置前缓冲