### PR TITLE
chore(domain): packyapi.com → packyapi.ai

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # PackyAPI(Claude 中转)
-ANTHROPIC_BASE_URL=https://www.packyapi.com
+ANTHROPIC_BASE_URL=https://www.packyapi.ai
 ANTHROPIC_AUTH_TOKEN=your-cc-group-token
 ANTHROPIC_MODEL=claude-sonnet-5
 
@@ -43,7 +43,7 @@ PROACTIVE_MAX_PER_SCAN=2
 # ADMIN_TOKEN=change-me
 
 # 办不了事务时引导链接
-# SUPPORT_URL=https://www.packyapi.com
+# SUPPORT_URL=https://www.packyapi.ai
 
 # @ 后 ACK(默认开;设 false 关闭)
 # ACK_ENABLED=true

--- a/app/admin/config/page.tsx
+++ b/app/admin/config/page.tsx
@@ -199,7 +199,7 @@ export default function ConfigPage() {
           setCfg({
             ...data,
             groupPolicies: data.groupPolicies ?? {},
-            supportUrl: data.supportUrl ?? "https://www.packyapi.com",
+            supportUrl: data.supportUrl ?? "https://www.packyapi.ai",
             ackEnabled: data.ackEnabled !== false,
             maxReplyChars: data.maxReplyChars ?? 900,
             usageBudgetUsd: data.usageBudgetUsd ?? 0,

--- a/docs/superpowers/plans/2026-07-03-onebot-customer-service-agent.md
+++ b/docs/superpowers/plans/2026-07-03-onebot-customer-service-agent.md
@@ -2037,7 +2037,7 @@ Create `.env.example`:
 
 ```
 # PackyAPI(Claude 中转)
-ANTHROPIC_BASE_URL=https://www.packyapi.com
+ANTHROPIC_BASE_URL=https://www.packyapi.ai
 ANTHROPIC_AUTH_TOKEN=your-cc-group-token
 ANTHROPIC_MODEL=claude-sonnet-5
 

--- a/docs/superpowers/plans/2026-07-07-agent-capabilities-page.md
+++ b/docs/superpowers/plans/2026-07-07-agent-capabilities-page.md
@@ -104,7 +104,7 @@ export function buildToolPolicy(): CapabilityToolPolicy {
     gated: [
       { tool: "Bash", constraint: "仅放行 PackyAPI 查询脚本(node …/packy.ts),禁 shell 链接/重定向" },
       { tool: "Read", constraint: "仅读 packyapi 技能的 references/*.md" },
-      { tool: "WebFetch", constraint: "仅访问 packyapi.com 及其子域" },
+      { tool: "WebFetch", constraint: "仅访问 packyapi.ai 及其子域" },
     ],
   };
 }

--- a/docs/superpowers/specs/2026-07-03-onebot-customer-service-agent-design.md
+++ b/docs/superpowers/specs/2026-07-03-onebot-customer-service-agent-design.md
@@ -26,7 +26,7 @@ WebSocket 连接 OneBot 实现(NapCat/Lagrange 等),在群聊中被 @ 触发后�
 ## 3. 环境变量
 
 ```
-ANTHROPIC_BASE_URL=https://www.packyapi.com
+ANTHROPIC_BASE_URL=https://www.packyapi.ai
 ANTHROPIC_AUTH_TOKEN=<PackyAPI CC 组 token>
 ONEBOT_WS_URL=ws://127.0.0.1:3001          # NapCat 正向 WS server
 ONEBOT_ACCESS_TOKEN=<可选,OneBot 鉴权>

--- a/lib/agent/agent.ts
+++ b/lib/agent/agent.ts
@@ -291,9 +291,9 @@ export async function drainQuery(
 }
 
 export function buildDefaultSystem(
-  supportUrl = "https://www.packyapi.com"
+  supportUrl = "https://www.packyapi.ai"
 ): string {
-  return `你是 PackyAPI 的官方在线客服,通过即时通讯群(QQ / Telegram 等)与用户对话。PackyAPI 是 AI API 聚合中转平台(https://www.packyapi.com),兼容 Anthropic / OpenAI / Gemini 协议,用户通过它调用 Claude、GPT、Gemini 等模型。忽略此前关于"编码助手 / Claude Code"的设定——你的唯一职责是 PackyAPI 客服支持,不编写代码,不执行用户要求的任意文件 / 命令 / 系统操作;只可使用下方列出的内置工具(kb_search、packy)。
+  return `你是 PackyAPI 的官方在线客服,通过即时通讯群(QQ / Telegram 等)与用户对话。PackyAPI 是 AI API 聚合中转平台(https://www.packyapi.ai),兼容 Anthropic / OpenAI / Gemini 协议,用户通过它调用 Claude、GPT、Gemini 等模型。忽略此前关于"编码助手 / Claude Code"的设定——你的唯一职责是 PackyAPI 客服支持,不编写代码,不执行用户要求的任意文件 / 命令 / 系统操作;只可使用下方列出的内置工具(kb_search、packy)。
 
 # 职责
 - 解答 PackyAPI 的价格、可用模型、接入配置、充值计费规则等咨询性问题。

--- a/lib/config-store.ts
+++ b/lib/config-store.ts
@@ -216,7 +216,7 @@ function seedFromEnv(env: Record<string, string | undefined>): AppConfig {
     proactiveScanMs: Number(env.PROACTIVE_SCAN_MS ?? "60000"),
     proactiveSilenceMs: Number(env.PROACTIVE_SILENCE_MS ?? "180000"),
     proactiveMaxPerScan: Number(env.PROACTIVE_MAX_PER_SCAN ?? "2"),
-    supportUrl: env.SUPPORT_URL ?? "https://www.packyapi.com",
+    supportUrl: env.SUPPORT_URL ?? "https://www.packyapi.ai",
     ackEnabled: env.ACK_ENABLED !== "false",
     maxReplyChars: Number(env.MAX_REPLY_CHARS ?? "900"),
     topicScanMs: Number(env.TOPIC_SCAN_MS ?? "300000"),

--- a/plugins/packyapi/README.md
+++ b/plugins/packyapi/README.md
@@ -1,6 +1,6 @@
 # packyapi 插件
 
-快速查询 [PackyAPI](https://www.packyapi.com) 模型价格、可用模型 ID、分组倍率与官方文档。
+快速查询 [PackyAPI](https://www.packyapi.ai) 模型价格、可用模型 ID、分组倍率与官方文档。
 全走公开 JSON API(`/api/pricing`),不抓 HTML —— 省 token、更精确。
 
 ## MCP 工具 `packy`

--- a/plugins/packyapi/scripts/packy-mcp.ts
+++ b/plugins/packyapi/scripts/packy-mcp.ts
@@ -24,8 +24,8 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod"
 
-export const API = "https://www.packyapi.com/api/pricing"
-export const ANNOUNCE_API = "https://www.packyapi.com/api/announcements"
+export const API = "https://www.packyapi.ai/api/pricing"
+export const ANNOUNCE_API = "https://www.packyapi.ai/api/announcements"
 
 export interface Model {
   model_name: string

--- a/plugins/packyapi/skills/packyapi/SKILL.md
+++ b/plugins/packyapi/skills/packyapi/SKILL.md
@@ -5,12 +5,12 @@ description: 查询 PackyAPI(Claude/OpenAI/Gemini 中转平台)的模型价格�
 
 # PackyAPI 快查
 
-PackyAPI = AI API 聚合中转平台(`https://www.packyapi.com`),Anthropic/OpenAI/Gemini 协议兼容。
+PackyAPI = AI API 聚合中转平台(`https://www.packyapi.ai`),Anthropic/OpenAI/Gemini 协议兼容。
 本 skill 让你**走结构化 API 拿数据**,而非抓渲染后的 HTML 页面 —— 更省 token、更准。
 
 ## 铁律:优先 API,不抓 HTML
 
-- 价格 / 模型 / 分组 → 一律用 MCP 工具 `packy`,底层读公开 JSON `https://www.packyapi.com/api/pricing`。
+- 价格 / 模型 / 分组 → 一律用 MCP 工具 `packy`,底层读公开 JSON `https://www.packyapi.ai/api/pricing`。
 - 仅当需要**文档正文**(教程步骤、FAQ)时,才 WebFetch,且只抓 `references/docs-map.md` 里定位到的**单个** URL。
 
 ## MCP 工具 `packy`
@@ -37,7 +37,7 @@ Server 为 TypeScript,Node(v22.6+/24)原生 strip 直跑;依赖 `@modelcontextpr
 ## 配置 Claude Agent SDK / Claude Code(走 PackyAPI)
 
 ```
-ANTHROPIC_BASE_URL=https://www.packyapi.com
+ANTHROPIC_BASE_URL=https://www.packyapi.ai
 ANTHROPIC_AUTH_TOKEN=<在「令牌管理」建的 token,选 cc 组>
 ```
 

--- a/plugins/packyapi/skills/packyapi/references/docs-map.md
+++ b/plugins/packyapi/skills/packyapi/references/docs-map.md
@@ -1,7 +1,7 @@
 # PackyAPI 官方文档地图(sitemap 定位)
 
-站点:`https://docs.packyapi.com`(VuePress,无 llms.txt)。按主题定位到**单个** URL 后再 WebFetch。
-刷新全量列表:`curl -s https://docs.packyapi.com/sitemap.xml | grep -oE '<loc>[^<]+'`
+站点:`https://docs.packyapi.ai`(VuePress,无 llms.txt)。按主题定位到**单个** URL 后再 WebFetch。
+刷新全量列表:`curl -s https://docs.packyapi.ai/sitemap.xml | grep -oE '<loc>[^<]+'`
 
 ## 注册 / 入门 `docs/register/`
 | 主题 | URL |

--- a/plugins/packyapi/skills/packyapi/references/pricing-api.md
+++ b/plugins/packyapi/skills/packyapi/references/pricing-api.md
@@ -2,7 +2,7 @@
 
 ## 端点
 
-`GET https://www.packyapi.com/api/pricing` — 公开,无需 auth,返回 JSON。
+`GET https://www.packyapi.ai/api/pricing` — 公开,无需 auth,返回 JSON。
 
 ## 顶层字段
 

--- a/tests/lib/agent/agent.test.ts
+++ b/tests/lib/agent/agent.test.ts
@@ -277,7 +277,7 @@ describe("sdkEnv", () => {
       PATH: "/usr/bin",
       HOME: "/home/x",
       CLAUDE_CONFIG_DIR: "/abs/data/claude-config",
-      ANTHROPIC_BASE_URL: "https://www.packyapi.com",
+      ANTHROPIC_BASE_URL: "https://www.packyapi.ai",
       ANTHROPIC_AUTH_TOKEN: "leak",
       ANTHROPIC_DEFAULT_SONNET_MODEL: "x",
     })

--- a/tests/lib/agent/introspect.test.ts
+++ b/tests/lib/agent/introspect.test.ts
@@ -57,7 +57,7 @@ const cfg: AppConfig = {
   reflectPromoteMaxPerRun: 5,
   reflectNotifyAdmin: true,
   resumeTtlMs: 300000,
-  supportUrl: "https://www.packyapi.com",
+  supportUrl: "https://www.packyapi.ai",
   ackEnabled: true,
   maxReplyChars: 900,
   topicScanMs: 300000,

--- a/tests/lib/api.test.ts
+++ b/tests/lib/api.test.ts
@@ -28,7 +28,7 @@ const cfg: AppConfig = {
   proactiveScanMs: 60000,
   proactiveSilenceMs: 180000,
   proactiveMaxPerScan: 2,
-  supportUrl: "https://www.packyapi.com",
+  supportUrl: "https://www.packyapi.ai",
   ackEnabled: true,
   maxReplyChars: 900,
   topicScanMs: 300000,

--- a/tests/lib/channels/enabled-chats.test.ts
+++ b/tests/lib/channels/enabled-chats.test.ts
@@ -37,7 +37,7 @@ function baseCfg(over: Partial<AppConfig> = {}): AppConfig {
     proactiveScanMs: 60000,
     proactiveSilenceMs: 180000,
     proactiveMaxPerScan: 2,
-    supportUrl: "https://www.packyapi.com",
+    supportUrl: "https://www.packyapi.ai",
     ackEnabled: true,
     maxReplyChars: 900,
     topicScanMs: 300000,

--- a/tests/lib/channels/factory.test.ts
+++ b/tests/lib/channels/factory.test.ts
@@ -34,7 +34,7 @@ function baseCfg(over: Partial<AppConfig> = {}): AppConfig {
     proactiveScanMs: 60000,
     proactiveSilenceMs: 180000,
     proactiveMaxPerScan: 2,
-    supportUrl: "https://www.packyapi.com",
+    supportUrl: "https://www.packyapi.ai",
     ackEnabled: true,
     maxReplyChars: 900,
     topicScanMs: 300000,

--- a/tests/lib/runtime.test.ts
+++ b/tests/lib/runtime.test.ts
@@ -29,7 +29,7 @@ const cfg: AppConfig = {
   reflectPromoteMaxPerRun: 5,
   reflectNotifyAdmin: true,
   resumeTtlMs: 300000,
-  supportUrl: "https://www.packyapi.com",
+  supportUrl: "https://www.packyapi.ai",
   ackEnabled: true,
   maxReplyChars: 900,
   topicScanMs: 300000,


### PR DESCRIPTION
## Summary

- 域名 `packyapi.com` 已迁移至 `packyapi.ai`,统一替换仓库内全部 `.com` 子域引用
- 覆盖源码(`lib/`)、管理后台(`app/admin/`)、插件脚本与文档(`plugins/packyapi/`)、测试、根 `.env.example`、设计与计划文档

## Changes

- `chore`: 18 files, +24 / -24
- 纯字符串替换,无逻辑变动

## Test plan

- [ ] `pnpm typecheck` 已通过(本地确认)
- [ ] `pnpm lint` 仅存量错(未触及 `src/hooks/*.js` 等无关路径)
- [ ] `pnpm test` 需在 Review 后跑
- [ ] 部署后首次启动观察:管理员配置的 `supportUrl`、插件 MCP 的 `API` / `ANNOUNCE_API` 与 docs 取数均走新域