### PR TITLE
fix(reflection): 升格时物理删除原反思 chunk,避免列表与检索残留

### DIFF
--- a/lib/db/repo.ts
+++ b/lib/db/repo.ts
@@ -1111,6 +1111,22 @@ export class Repo {
     })()
   }
 
+  // 单 chunk 物理删除:kb_vec + kb_chunks + reflection_meta 三表联动,事务内完成。
+  // 用于反思条目升格后清理原 human-reflection chunk(避免列表/检索双重残留)。
+  // 返回是否实际删除(0 = 无此 id)。
+  deleteKbChunk(chunkId: number): boolean {
+    return this.db.transaction(() => {
+      this.db.prepare("DELETE FROM kb_vec WHERE chunk_id = ?").run(chunkId)
+      const info = this.db
+        .prepare("DELETE FROM kb_chunks WHERE id = ?")
+        .run(chunkId)
+      this.db
+        .prepare("DELETE FROM reflection_meta WHERE chunk_id = ?")
+        .run(chunkId)
+      return info.changes > 0
+    })()
+  }
+
   // 重命名文档:同步更新 doc;source 若等于旧路径也一并改(文件入库时 source=路径)。
   renameKbDoc(from: string, to: string): number {
     const info = this.db

--- a/lib/reflect-promote.ts
+++ b/lib/reflect-promote.ts
@@ -31,9 +31,9 @@ export interface ApplyPromoteOpts {
  * 将一条 human-reflection 升格为正式文档:
  * 1. 写 docs/kb/promoted/reflection-{id}.md
  * 2. 立即 embed 写入 kb_chunks(doc=相对路径),Agent 检索可命中
- * 3. 标记 status=promoted(反思侧不再参与检索,避免与正式文档重复)
+ * 3. 物理删除原反思 chunk,避免列表 / 检索残留
  *
- * 幂等:已 promoted 则返回 already,不重写(除非需要可强制)。
+ * 幂等:已 promoted 则返回 already,不重写、不再删(原 chunk 早已不在)。
  */
 export async function applyPromote(
   opts: ApplyPromoteOpts
@@ -69,7 +69,8 @@ export async function applyPromote(
   // 正式文档入库:先清旧分块再写,保证幂等
   repo.deleteKbDoc(rel)
   repo.insertKbEntry(rel, body, rel, await embed(body))
-  repo.setReflectionStatus(chunkId, "promoted")
+  // 原反思 chunk 物理删除,避免 list / 检索双份残留
+  repo.deleteKbChunk(chunkId)
 
   return { ok: true, file: rel, content: entry.content }
 }

--- a/tests/lib/agent/reflection-promoter.test.ts
+++ b/tests/lib/agent/reflection-promoter.test.ts
@@ -82,9 +82,8 @@ describe("reflect-promote helpers", () => {
     expect(r.file).toBe("promoted/reflection-" + id + ".md")
     expect(writes).toHaveLength(1)
     expect(writes[0]!.body).toContain("退款 7 天到账")
-    expect(repo.reflectionEntries().find((e) => e.id === id)!.status).toBe(
-      "promoted"
-    )
+    // 原反思 chunk 已物理删除:不再出现在 reflectionEntries,也不在 searchKb
+    expect(repo.reflectionEntries().find((e) => e.id === id)).toBeUndefined()
     // 反思侧不再命中;正式文档命中
     const hits = repo.searchKb(vec(), 5)
     expect(hits.some((h) => h.content.includes("退款"))).toBe(true)
@@ -98,7 +97,7 @@ describe("reflect-promote helpers", () => {
     expect(repo.kbChunksByDoc(r.file).length).toBeGreaterThan(0)
   })
 
-  it("applyPromote 幂等:已升格 → already", async () => {
+  it("applyPromote 幂等:已升格 → 原 chunk 已物理删除,再调返回条目不存在", async () => {
     const id = repo.insertKbEntry(
       "human-reflection",
       "faq",
@@ -113,6 +112,7 @@ describe("reflect-promote helpers", () => {
       writeFileFn: async () => {},
       mkdirFn: async () => {},
     })
+    // 第二次写盘函数应不被调用(早期 return),且语义变成"条目不存在"
     const r2 = await applyPromote({
       repo,
       chunkId: id,
@@ -122,7 +122,8 @@ describe("reflect-promote helpers", () => {
       },
       mkdirFn: async () => {},
     })
-    expect(r2.ok && r2.already).toBe(true)
+    expect(r2.ok).toBe(false)
+    if (!r2.ok) expect(r2.reason).toBe("条目不存在")
   })
 
   it("applyPromote 拒绝 rejected", async () => {

--- a/tests/lib/db/repo.reflection.test.ts
+++ b/tests/lib/db/repo.reflection.test.ts
@@ -128,3 +128,36 @@ describe("reflection_meta / reflectionEntries", () => {
     expect(rc.map((r) => r.ts)).toEqual([300, 200])
   })
 })
+
+describe("deleteKbChunk", () => {
+  it("三表联动:kb_vec + kb_chunks + reflection_meta 全删", () => {
+    const id = repo.insertKbEntry(
+      "human-reflection",
+      "原文",
+      "human-reflection:qq:100:5",
+      vec()
+    )
+    repo.insertReflectionMeta(id, "qq", "100", "问", "答")
+    expect(repo.deleteKbChunk(id)).toBe(true)
+    // 反思 list 查不到(LEFT JOIN 没了)
+    expect(repo.reflectionEntries().find((e) => e.id === id)).toBeUndefined()
+    // 检索也不再命中
+    expect(repo.searchKb(vec(), 5).find((h) => h.id === id)).toBeUndefined()
+    // meta 行也被清,不留孤儿(直接查表)
+    const d = (repo as unknown as { db: import("better-sqlite3").Database })
+      .db
+    expect(
+      d.prepare("SELECT 1 FROM reflection_meta WHERE chunk_id = ?").get(id)
+    ).toBeUndefined()
+  })
+
+  it("不存在 id → 返回 false,无副作用", () => {
+    expect(repo.deleteKbChunk(99999)).toBe(false)
+  })
+
+  it("无 meta 的 chunk 也能删(不报错)", () => {
+    const id = repo.insertKbChunk("human-reflection", "无meta", "human-reflection:qq:0:1")
+    expect(repo.deleteKbChunk(id)).toBe(true)
+    expect(repo.reflectionEntries()).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary
- 反思条目升格后,`applyPromote` 现在物理删除原 `doc='human-reflection'` chunk,而非仅标 `status=promoted` 留尸
- 新增 `Repo.deleteKbChunk(chunkId)`,事务内清 `kb_vec` + `kb_chunks` + `reflection_meta` 三表
- `searchKb` 的 `NOT IN ('rejected','promoted')` 过滤保留,作历史数据残留防御

## Background
反思管理后台"知识条目"列表越积越多,带"已升格" badge 的条目长期占行;每群 `sedimentedCount` 也把这些僵尸条目算进去,数字虚高。检索侧靠 status 过滤防御,根因(物理冗余)未消除。

## Changes
- `lib/db/repo.ts`:新增 `deleteKbChunk(chunkId)`
- `lib/reflect-promote.ts`:`applyPromote` 末尾改调 `deleteKbChunk`,注释同步
- `tests/lib/db/repo.reflection.test.ts`:加三表联动 / 不存在 id / 无 meta 三例
- `tests/lib/agent/reflection-promoter.test.ts`:更新两处断言(原 chunk 已物理删除,二次 `applyPromote` 返回"条目不存在")

## Test plan
- [x] `pnpm typecheck` 过
- [x] `pnpm test` 607 passed (57 files)
- [x] `pnpm lint` 改动文件无新增错(2 个 pre-existing `no-explicit-any`)
- [ ] 手动验收:后台 `/admin/reflection` 升格若干条后,列表/各群 `sedimentedCount` 数字下降;agent 检索仍能命中新升格的 `promoted/reflection-*.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)