### PR TITLE
feat(config): reorganize settings navigation

### DIFF
--- a/app/admin/config/page.tsx
+++ b/app/admin/config/page.tsx
@@ -3,18 +3,12 @@
 import {
   Save,
   Cable,
-  Send,
   MessageSquareText,
-  Bot,
-  MessagesSquare,
   Brain,
-  Zap,
-  Bell,
-  HardDrive,
-  Shield,
-  Palette,
+  Settings2,
+  Wrench,
 } from "lucide-react"
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
@@ -29,11 +23,27 @@ import { AdminSettings } from "@/components/admin/config/admin-settings"
 import { ReplySettings } from "@/components/admin/config/reply-settings"
 import { SdkSettings } from "@/components/admin/config/sdk-settings"
 import { SessionSettings } from "@/components/admin/config/session-settings"
+import { KnowledgePrefetchSettings } from "@/components/admin/config/knowledge-settings"
 import { ReflectSettings } from "@/components/admin/config/reflect-settings"
 import { ProactiveSettings } from "@/components/admin/config/proactive-settings"
 import { NotifySettings } from "@/components/admin/config/notify-settings"
 import { StorageSettings } from "@/components/admin/config/storage-settings"
 import { BrandSettings } from "@/components/admin/config/brand-settings"
+
+function CategoryHeader({
+  title,
+  description,
+}: {
+  title: string
+  description: string
+}) {
+  return (
+    <div className="space-y-1">
+      <h2 className="text-lg font-semibold tracking-tight">{title}</h2>
+      <p className="text-sm text-muted-foreground">{description}</p>
+    </div>
+  )
+}
 
 export default function ConfigPage() {
   const {
@@ -74,7 +84,7 @@ export default function ConfigPage() {
     <PageShell>
       <PageHeader
         title="配置"
-        description="修改后保存即生效。通道连接与业务参数分栏。"
+        description="按用途整理品牌、渠道、对话策略与系统参数。修改后保存即生效。"
         actions={
           <Button onClick={save} disabled={busy || !cfg}>
             {busy ? (
@@ -91,121 +101,195 @@ export default function ConfigPage() {
       {!cfg && !error && <Skeleton className="h-72 w-full" />}
 
       {cfg && (
-        <Tabs defaultValue="qq">
-          <TabsList className="h-auto w-full flex-wrap justify-start">
-            <TabsTrigger value="brand">
-              <Palette data-icon="inline-start" /> 品牌
-            </TabsTrigger>
-            <TabsTrigger value="qq">
-              <Cable data-icon="inline-start" /> QQ 通道
-            </TabsTrigger>
-            <TabsTrigger value="tg">
-              <Send data-icon="inline-start" /> TG 通道
-            </TabsTrigger>
-            <TabsTrigger value="admin">
-              <Shield data-icon="inline-start" /> 管理面
-            </TabsTrigger>
-            <TabsTrigger value="reply">
-              <MessageSquareText data-icon="inline-start" /> 回复体验
-            </TabsTrigger>
-            <TabsTrigger value="session">
-              <MessagesSquare data-icon="inline-start" /> 会话
-            </TabsTrigger>
-            <TabsTrigger value="reflect">
-              <Brain data-icon="inline-start" /> 反思
-            </TabsTrigger>
-            <TabsTrigger value="proactive">
-              <Zap data-icon="inline-start" /> 主动回复
-            </TabsTrigger>
-            <TabsTrigger value="notify">
-              <Bell data-icon="inline-start" /> 通知
-            </TabsTrigger>
-            <TabsTrigger value="sdk">
-              <Bot data-icon="inline-start" /> Claude SDK
-            </TabsTrigger>
-            <TabsTrigger value="storage">
-              <HardDrive data-icon="inline-start" /> 存储
-            </TabsTrigger>
-          </TabsList>
+        <Tabs
+          defaultValue="base"
+          orientation="vertical"
+          className="grid gap-4 md:grid-cols-[220px_minmax(0,1fr)] md:items-start"
+        >
+          <div className="h-fit md:sticky md:top-20">
+            <div className="mb-1 px-2 pt-1 pb-1 text-[11px] font-semibold tracking-wide text-muted-foreground">
+              设置分类
+            </div>
+            <TabsList
+              variant="line"
+              aria-label="设置分类"
+              className="grid h-fit w-full grid-cols-2 content-start gap-1 rounded-xl border bg-muted/30 p-2 md:grid-cols-1 md:rounded-lg md:border-0 md:bg-muted/40 md:p-1"
+            >
+              <TabsTrigger
+                value="base"
+                className="h-auto min-h-10 justify-start gap-2 px-3 py-2 text-left"
+              >
+                <Settings2 data-icon="inline-start" />
+                <span className="min-w-0">
+                  <span className="block">基础与管理</span>
+                  <span className="hidden text-[11px] font-normal text-muted-foreground md:block">
+                    品牌与管理命令
+                  </span>
+                </span>
+              </TabsTrigger>
+              <TabsTrigger
+                value="channels"
+                className="h-auto min-h-10 justify-start gap-2 px-3 py-2 text-left"
+              >
+                <Cable data-icon="inline-start" />
+                <span className="min-w-0">
+                  <span className="block">渠道接入</span>
+                  <span className="hidden text-[11px] font-normal text-muted-foreground md:block">
+                    QQ 与 Telegram
+                  </span>
+                </span>
+              </TabsTrigger>
+              <TabsTrigger
+                value="conversation"
+                className="h-auto min-h-10 justify-start gap-2 px-3 py-2 text-left"
+              >
+                <MessageSquareText data-icon="inline-start" />
+                <span className="min-w-0">
+                  <span className="block">对话与自动化</span>
+                  <span className="hidden text-[11px] font-normal text-muted-foreground md:block">
+                    回复、会话、主动补位
+                  </span>
+                </span>
+              </TabsTrigger>
+              <TabsTrigger
+                value="knowledge"
+                className="h-auto min-h-10 justify-start gap-2 px-3 py-2 text-left"
+              >
+                <Brain data-icon="inline-start" />
+                <span className="min-w-0">
+                  <span className="block">知识与通知</span>
+                  <span className="hidden text-[11px] font-normal text-muted-foreground md:block">
+                    预检索、反思与提醒
+                  </span>
+                </span>
+              </TabsTrigger>
+              <TabsTrigger
+                value="advanced"
+                className="h-auto min-h-10 justify-start gap-2 px-3 py-2 text-left"
+              >
+                <Wrench data-icon="inline-start" />
+                <span className="min-w-0">
+                  <span className="block">系统高级</span>
+                  <span className="hidden text-[11px] font-normal text-muted-foreground md:block">
+                    SDK 与存储路径
+                  </span>
+                </span>
+              </TabsTrigger>
+            </TabsList>
+          </div>
 
-          <BrandSettings cfg={cfg} updateField={updateField} />
+          <div className="min-w-0">
+            <TabsContent value="base" className="m-0 space-y-4">
+              <CategoryHeader
+                title="基础与管理"
+                description="先确认对外身份，再设置管理命令和转人工的接收位置。"
+              />
+              <BrandSettings cfg={cfg} updateField={updateField} embedded />
+              <AdminSettings
+                cfg={cfg}
+                updateField={updateField}
+                fieldValue={fieldValue}
+                groups={groups}
+                groupsLoading={groupsLoading}
+                adminQq={adminQq}
+                setAdminChannel={setAdminChannel}
+                setAdminChatId={setAdminChatId}
+                adminGroupOptions={adminGroupOptions}
+                adminTgOptions={adminTgOptions}
+                embedded
+              />
+            </TabsContent>
 
-          <QqSettings
-            cfg={cfg}
-            updateField={updateField}
-            fieldValue={fieldValue}
-            groups={groups}
-            groupsLoading={groupsLoading}
-            admins={admins}
-            adminsLoading={adminsLoading}
-            enabledQqIds={enabledQqIds}
-            adminQq={adminQq}
-            toggleGroup={toggleGroup}
-            adminLabel={adminLabel}
-            toggleExtraAt={toggleExtraAt}
-            groupName={groupName}
-          />
+            <TabsContent value="channels" className="m-0 space-y-4">
+              <CategoryHeader
+                title="渠道接入"
+                description="配置消息通道和生效会话；未配置凭证的通道不会启动。"
+              />
+              <QqSettings
+                cfg={cfg}
+                updateField={updateField}
+                fieldValue={fieldValue}
+                groups={groups}
+                groupsLoading={groupsLoading}
+                admins={admins}
+                adminsLoading={adminsLoading}
+                enabledQqIds={enabledQqIds}
+                adminQq={adminQq}
+                toggleGroup={toggleGroup}
+                adminLabel={adminLabel}
+                toggleExtraAt={toggleExtraAt}
+                groupName={groupName}
+                embedded
+              />
+              <TgSettings
+                cfg={cfg}
+                setCfg={setCfg}
+                enabledTgIds={enabledTgIds}
+                tgChatDraft={tgChatDraft}
+                setTgChatDraft={setTgChatDraft}
+                addTgChat={addTgChat}
+                removeTgChat={removeTgChat}
+                tgTokenConfigured={tgTokenConfigured}
+                tgBypassWarn={tgBypassWarn}
+                tgChannel={tgChannel}
+                tgChatTitle={tgChatTitle}
+                embedded
+              />
+            </TabsContent>
 
-          <TgSettings
-            cfg={cfg}
-            setCfg={setCfg}
-            enabledTgIds={enabledTgIds}
-            tgChatDraft={tgChatDraft}
-            setTgChatDraft={setTgChatDraft}
-            addTgChat={addTgChat}
-            removeTgChat={removeTgChat}
-            tgTokenConfigured={tgTokenConfigured}
-            tgBypassWarn={tgBypassWarn}
-            tgChannel={tgChannel}
-            tgChatTitle={tgChatTitle}
-          />
+            <TabsContent value="conversation" className="m-0 space-y-4">
+              <CategoryHeader
+                title="对话与自动化"
+                description="调整回复呈现、会话生命周期和无人应答时的主动补位策略。"
+              />
+              <ReplySettings
+                cfg={cfg}
+                setCfg={setCfg}
+                updateField={updateField}
+                fieldValue={fieldValue}
+                embedded
+              />
+              <SessionSettings cfg={cfg} setCfg={setCfg} embedded />
+              <ProactiveSettings
+                cfg={cfg}
+                setCfg={setCfg}
+                updateField={updateField}
+                fieldValue={fieldValue}
+                embedded
+              />
+            </TabsContent>
 
-          <AdminSettings
-            cfg={cfg}
-            updateField={updateField}
-            fieldValue={fieldValue}
-            groups={groups}
-            groupsLoading={groupsLoading}
-            adminQq={adminQq}
-            setAdminChannel={setAdminChannel}
-            setAdminChatId={setAdminChatId}
-            adminGroupOptions={adminGroupOptions}
-            adminTgOptions={adminTgOptions}
-          />
+            <TabsContent value="knowledge" className="m-0 space-y-4">
+              <CategoryHeader
+                title="知识与通知"
+                description="管理知识沉淀节奏，并决定是否向管理面发送相关运行提醒。"
+              />
+              <KnowledgePrefetchSettings
+                cfg={cfg}
+                setCfg={setCfg}
+                updateField={updateField}
+                fieldValue={fieldValue}
+                embedded
+              />
+              <ReflectSettings
+                cfg={cfg}
+                setCfg={setCfg}
+                updateField={updateField}
+                fieldValue={fieldValue}
+                embedded
+              />
+              <NotifySettings cfg={cfg} setCfg={setCfg} embedded />
+            </TabsContent>
 
-          <ReplySettings
-            cfg={cfg}
-            setCfg={setCfg}
-            updateField={updateField}
-            fieldValue={fieldValue}
-          />
-
-          <SdkSettings cfg={cfg} updateField={updateField} />
-
-          <SessionSettings
-            cfg={cfg}
-            setCfg={setCfg}
-            updateField={updateField}
-            fieldValue={fieldValue}
-          />
-
-          <ReflectSettings
-            cfg={cfg}
-            setCfg={setCfg}
-            updateField={updateField}
-            fieldValue={fieldValue}
-          />
-
-          <ProactiveSettings
-            cfg={cfg}
-            setCfg={setCfg}
-            updateField={updateField}
-            fieldValue={fieldValue}
-          />
-
-          <NotifySettings cfg={cfg} setCfg={setCfg} />
-
-          <StorageSettings cfg={cfg} updateField={updateField} />
+            <TabsContent value="advanced" className="m-0 space-y-4">
+              <CategoryHeader
+                title="系统高级"
+                description="仅在需要调整运行目录或数据库位置时修改这些参数。"
+              />
+              <SdkSettings cfg={cfg} updateField={updateField} embedded />
+              <StorageSettings cfg={cfg} updateField={updateField} embedded />
+            </TabsContent>
+          </div>
         </Tabs>
       )}
     </PageShell>

--- a/components/admin/config/admin-settings.tsx
+++ b/components/admin/config/admin-settings.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { TabsContent } from "@/components/ui/tabs"
 import {
   Field,
   FieldDescription,
@@ -17,6 +16,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { SectionCard } from "@/components/admin/section-card"
+import { ConfigTabContent } from "./config-tab-content"
 
 import type { ConfigForm } from "./use-config-form"
 
@@ -31,6 +31,7 @@ export function AdminSettings({
   setAdminChatId,
   adminGroupOptions,
   adminTgOptions,
+  embedded = false,
 }: Pick<
   ConfigForm,
   | "cfg"
@@ -43,9 +44,9 @@ export function AdminSettings({
   | "setAdminChatId"
   | "adminGroupOptions"
   | "adminTgOptions"
->) {
+> & { embedded?: boolean }) {
   return (
-    <TabsContent value="admin">
+    <ConfigTabContent value="admin" embedded={embedded}>
       <SectionCard
         title="管理面"
         description="转人工/反思/用量告警抄送与 !reset / !resume 落点。可与生效白名单无关。"
@@ -161,6 +162,6 @@ export function AdminSettings({
           </Field>
         </FieldGroup>
       </SectionCard>
-    </TabsContent>
+    </ConfigTabContent>
   )
 }

--- a/components/admin/config/brand-settings.tsx
+++ b/components/admin/config/brand-settings.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { TabsContent } from "@/components/ui/tabs"
 import {
   Field,
   FieldDescription,
@@ -9,6 +8,7 @@ import {
 } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { SectionCard } from "@/components/admin/section-card"
+import { ConfigTabContent } from "./config-tab-content"
 
 import type { ConfigForm } from "./use-config-form"
 
@@ -16,9 +16,10 @@ import type { ConfigForm } from "./use-config-form"
 export function BrandSettings({
   cfg,
   updateField,
-}: Pick<ConfigForm, "cfg" | "updateField">) {
+  embedded = false,
+}: Pick<ConfigForm, "cfg" | "updateField"> & { embedded?: boolean }) {
   return (
-    <TabsContent value="brand">
+    <ConfigTabContent value="brand" embedded={embedded}>
       <SectionCard
         title="品牌"
         description="设置对外名称与客服身份。保存后会同步到管理后台和 Agent。"
@@ -50,6 +51,6 @@ export function BrandSettings({
           </Field>
         </FieldGroup>
       </SectionCard>
-    </TabsContent>
+    </ConfigTabContent>
   )
 }

--- a/components/admin/config/config-tab-content.tsx
+++ b/components/admin/config/config-tab-content.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react"
+import { TabsContent } from "@/components/ui/tabs"
+
+/**
+ * 配置区块既可以独立作为旧式标签页渲染,也可以嵌入新的分类面板。
+ * 保留独立模式方便区块复用,分类页则用 embedded 把多个相关区块放在一起。
+ */
+export function ConfigTabContent({
+  value,
+  embedded = false,
+  children,
+}: {
+  value: string
+  embedded?: boolean
+  children: ReactNode
+}) {
+  if (embedded) return <>{children}</>
+  return <TabsContent value={value}>{children}</TabsContent>
+}

--- a/components/admin/config/knowledge-settings.tsx
+++ b/components/admin/config/knowledge-settings.tsx
@@ -1,0 +1,75 @@
+"use client"
+
+import {
+  Field,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+} from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
+import { Checkbox } from "@/components/ui/checkbox"
+import { SectionCard } from "@/components/admin/section-card"
+
+import { ConfigTabContent } from "./config-tab-content"
+import type { ConfigForm } from "./use-config-form"
+
+/** 知识库在每轮对话前的自动预检索设置。 */
+export function KnowledgePrefetchSettings({
+  cfg,
+  setCfg,
+  updateField,
+  fieldValue,
+  embedded = false,
+}: Pick<ConfigForm, "cfg" | "setCfg" | "updateField" | "fieldValue"> & {
+  embedded?: boolean
+}) {
+  return (
+    <ConfigTabContent value="knowledge-prefetch" embedded={embedded}>
+      <SectionCard
+        title="知识库预检索"
+        description="每轮消息进模型前自动检索知识库并把片段拼进提问，不依赖模型自己决定要不要查。"
+      >
+        <FieldGroup>
+          <Field orientation="horizontal">
+            <Checkbox
+              id="kbPrefetchEnabled"
+              checked={cfg.kbPrefetchEnabled !== false}
+              onCheckedChange={(v) =>
+                setCfg({ ...cfg, kbPrefetchEnabled: v === true })
+              }
+            />
+            <FieldLabel htmlFor="kbPrefetchEnabled">开启预检索注入</FieldLabel>
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="kbPrefetchTopK">注入片段条数</FieldLabel>
+            <Input
+              id="kbPrefetchTopK"
+              inputMode="numeric"
+              value={fieldValue("kbPrefetchTopK")}
+              onChange={(e) => updateField("kbPrefetchTopK", e.target.value)}
+            />
+            <FieldDescription>
+              默认 5。调小可压住长会话的上下文增长。
+            </FieldDescription>
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="kbPrefetchMaxDistance">
+              相关性距离上限
+            </FieldLabel>
+            <Input
+              id="kbPrefetchMaxDistance"
+              inputMode="decimal"
+              value={fieldValue("kbPrefetchMaxDistance")}
+              onChange={(e) =>
+                updateField("kbPrefetchMaxDistance", e.target.value)
+              }
+            />
+            <FieldDescription>
+              越大越宽松;向量 L2 距离,1.0 约等于余弦相似度 0.5。默认 1.0。
+            </FieldDescription>
+          </Field>
+        </FieldGroup>
+      </SectionCard>
+    </ConfigTabContent>
+  )
+}

--- a/components/admin/config/notify-settings.tsx
+++ b/components/admin/config/notify-settings.tsx
@@ -1,18 +1,19 @@
 "use client"
 
-import { TabsContent } from "@/components/ui/tabs"
 import { Field, FieldGroup, FieldLabel } from "@/components/ui/field"
 import { Checkbox } from "@/components/ui/checkbox"
 import { SectionCard } from "@/components/admin/section-card"
+import { ConfigTabContent } from "./config-tab-content"
 
 import type { ConfigForm } from "./use-config-form"
 
 export function NotifySettings({
   cfg,
   setCfg,
-}: Pick<ConfigForm, "cfg" | "setCfg">) {
+  embedded = false,
+}: Pick<ConfigForm, "cfg" | "setCfg"> & { embedded?: boolean }) {
   return (
-    <TabsContent value="notify">
+    <ConfigTabContent value="notify" embedded={embedded}>
       <SectionCard title="通知" description="向管理面推送的运行通知。">
         <FieldGroup>
           <Field orientation="horizontal">
@@ -27,6 +28,6 @@ export function NotifySettings({
           </Field>
         </FieldGroup>
       </SectionCard>
-    </TabsContent>
+    </ConfigTabContent>
   )
 }

--- a/components/admin/config/proactive-settings.tsx
+++ b/components/admin/config/proactive-settings.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { TabsContent } from "@/components/ui/tabs"
 import {
   Field,
   FieldDescription,
@@ -10,6 +9,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Checkbox } from "@/components/ui/checkbox"
 import { SectionCard } from "@/components/admin/section-card"
+import { ConfigTabContent } from "./config-tab-content"
 
 import { msToSec, secToMs } from "./form-values"
 import type { ConfigForm } from "./use-config-form"
@@ -19,9 +19,12 @@ export function ProactiveSettings({
   setCfg,
   updateField,
   fieldValue,
-}: Pick<ConfigForm, "cfg" | "setCfg" | "updateField" | "fieldValue">) {
+  embedded = false,
+}: Pick<ConfigForm, "cfg" | "setCfg" | "updateField" | "fieldValue"> & {
+  embedded?: boolean
+}) {
   return (
-    <TabsContent value="proactive">
+    <ConfigTabContent value="proactive" embedded={embedded}>
       <SectionCard
         title="主动回复"
         description="无人应答时谨慎补位。也可在主动回复页一键开关。"
@@ -84,6 +87,6 @@ export function ProactiveSettings({
           </Field>
         </FieldGroup>
       </SectionCard>
-    </TabsContent>
+    </ConfigTabContent>
   )
 }

--- a/components/admin/config/qq-settings.tsx
+++ b/components/admin/config/qq-settings.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { ChevronsUpDown, X } from "lucide-react"
-import { TabsContent } from "@/components/ui/tabs"
 import {
   Field,
   FieldDescription,
@@ -26,6 +25,7 @@ import {
 import { Checkbox } from "@/components/ui/checkbox"
 import { Badge } from "@/components/ui/badge"
 import { SectionCard } from "@/components/admin/section-card"
+import { ConfigTabContent } from "./config-tab-content"
 
 import type { ConfigForm } from "./use-config-form"
 
@@ -46,6 +46,7 @@ export function QqSettings({
   adminLabel,
   toggleExtraAt,
   groupName,
+  embedded = false,
 }: Pick<
   ConfigForm,
   | "cfg"
@@ -61,9 +62,9 @@ export function QqSettings({
   | "adminLabel"
   | "toggleExtraAt"
   | "groupName"
->) {
+> & { embedded?: boolean }) {
   return (
-    <TabsContent value="qq">
+    <ConfigTabContent value="qq" embedded={embedded}>
       <SectionCard title="QQ 通道" description="OneBot 连接地址与群相关参数。">
         <FieldGroup>
           <Field>
@@ -258,6 +259,6 @@ export function QqSettings({
           </Field>
         </FieldGroup>
       </SectionCard>
-    </TabsContent>
+    </ConfigTabContent>
   )
 }

--- a/components/admin/config/reflect-settings.tsx
+++ b/components/admin/config/reflect-settings.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { TabsContent } from "@/components/ui/tabs"
 import {
   Field,
   FieldDescription,
@@ -9,6 +8,7 @@ import {
 } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { SectionCard } from "@/components/admin/section-card"
+import { ConfigTabContent } from "./config-tab-content"
 
 import { msToMin, minToMs, msToHr, hrToMs } from "./form-values"
 import type { ConfigForm } from "./use-config-form"
@@ -18,9 +18,12 @@ export function ReflectSettings({
   setCfg,
   updateField,
   fieldValue,
-}: Pick<ConfigForm, "cfg" | "setCfg" | "updateField" | "fieldValue">) {
+  embedded = false,
+}: Pick<ConfigForm, "cfg" | "setCfg" | "updateField" | "fieldValue"> & {
+  embedded?: boolean
+}) {
   return (
-    <TabsContent value="reflect">
+    <ConfigTabContent value="reflect" embedded={embedded}>
       <SectionCard
         title="反思(知识沉淀)"
         description="从人工答复提炼知识。时间单位：分钟 / 小时。"
@@ -151,6 +154,6 @@ export function ReflectSettings({
           </Field>
         </FieldGroup>
       </SectionCard>
-    </TabsContent>
+    </ConfigTabContent>
   )
 }

--- a/components/admin/config/reply-settings.tsx
+++ b/components/admin/config/reply-settings.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { TabsContent } from "@/components/ui/tabs"
 import {
   Field,
   FieldDescription,
@@ -10,6 +9,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Checkbox } from "@/components/ui/checkbox"
 import { SectionCard } from "@/components/admin/section-card"
+import { ConfigTabContent } from "./config-tab-content"
 
 import type { ConfigForm } from "./use-config-form"
 
@@ -18,9 +18,12 @@ export function ReplySettings({
   setCfg,
   updateField,
   fieldValue,
-}: Pick<ConfigForm, "cfg" | "setCfg" | "updateField" | "fieldValue">) {
+  embedded = false,
+}: Pick<ConfigForm, "cfg" | "setCfg" | "updateField" | "fieldValue"> & {
+  embedded?: boolean
+}) {
   return (
-    <TabsContent value="reply">
+    <ConfigTabContent value="reply" embedded={embedded}>
       <SectionCard
         title="回复体验"
         description="收到消息确认、支持链接与长文拆分。"
@@ -75,6 +78,6 @@ export function ReplySettings({
           </Field>
         </FieldGroup>
       </SectionCard>
-    </TabsContent>
+    </ConfigTabContent>
   )
 }

--- a/components/admin/config/sdk-settings.tsx
+++ b/components/admin/config/sdk-settings.tsx
@@ -1,18 +1,19 @@
 "use client"
 
-import { TabsContent } from "@/components/ui/tabs"
 import { Field, FieldGroup, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { SectionCard } from "@/components/admin/section-card"
+import { ConfigTabContent } from "./config-tab-content"
 
 import type { ConfigForm } from "./use-config-form"
 
 export function SdkSettings({
   cfg,
   updateField,
-}: Pick<ConfigForm, "cfg" | "updateField">) {
+  embedded = false,
+}: Pick<ConfigForm, "cfg" | "updateField"> & { embedded?: boolean }) {
   return (
-    <TabsContent value="sdk">
+    <ConfigTabContent value="sdk" embedded={embedded}>
       <SectionCard
         title="Claude Agent SDK"
         description="模型与 API 密钥请直接编辑配置目录下的 settings.json，本页仅管理配置路径。"
@@ -29,6 +30,6 @@ export function SdkSettings({
           </Field>
         </FieldGroup>
       </SectionCard>
-    </TabsContent>
+    </ConfigTabContent>
   )
 }

--- a/components/admin/config/session-settings.tsx
+++ b/components/admin/config/session-settings.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { TabsContent } from "@/components/ui/tabs"
 import {
   Field,
   FieldDescription,
@@ -8,8 +7,8 @@ import {
   FieldLabel,
 } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
-import { Checkbox } from "@/components/ui/checkbox"
 import { SectionCard } from "@/components/admin/section-card"
+import { ConfigTabContent } from "./config-tab-content"
 
 import { msToMin, minToMs } from "./form-values"
 import type { ConfigForm } from "./use-config-form"
@@ -17,11 +16,12 @@ import type { ConfigForm } from "./use-config-form"
 export function SessionSettings({
   cfg,
   setCfg,
-  updateField,
-  fieldValue,
-}: Pick<ConfigForm, "cfg" | "setCfg" | "updateField" | "fieldValue">) {
+  embedded = false,
+}: Pick<ConfigForm, "cfg" | "setCfg"> & {
+  embedded?: boolean
+}) {
   return (
-    <TabsContent value="session">
+    <ConfigTabContent value="session" embedded={embedded}>
       <SectionCard title="会话" description="空闲超时后开启新对话。">
         <FieldGroup>
           <Field>
@@ -38,52 +38,6 @@ export function SessionSettings({
           </Field>
         </FieldGroup>
       </SectionCard>
-
-      <SectionCard
-        title="知识库预检索"
-        description="每轮消息进模型前自动检索知识库并把片段拼进提问，不依赖模型自己决定要不要查。"
-      >
-        <FieldGroup>
-          <Field orientation="horizontal">
-            <Checkbox
-              id="kbPrefetchEnabled"
-              checked={cfg.kbPrefetchEnabled !== false}
-              onCheckedChange={(v) =>
-                setCfg({ ...cfg, kbPrefetchEnabled: v === true })
-              }
-            />
-            <FieldLabel htmlFor="kbPrefetchEnabled">开启预检索注入</FieldLabel>
-          </Field>
-          <Field>
-            <FieldLabel htmlFor="kbPrefetchTopK">注入片段条数</FieldLabel>
-            <Input
-              id="kbPrefetchTopK"
-              inputMode="numeric"
-              value={fieldValue("kbPrefetchTopK")}
-              onChange={(e) => updateField("kbPrefetchTopK", e.target.value)}
-            />
-            <FieldDescription>
-              默认 5。调小可压住长会话的上下文增长。
-            </FieldDescription>
-          </Field>
-          <Field>
-            <FieldLabel htmlFor="kbPrefetchMaxDistance">
-              相关性距离上限
-            </FieldLabel>
-            <Input
-              id="kbPrefetchMaxDistance"
-              inputMode="decimal"
-              value={fieldValue("kbPrefetchMaxDistance")}
-              onChange={(e) =>
-                updateField("kbPrefetchMaxDistance", e.target.value)
-              }
-            />
-            <FieldDescription>
-              越大越宽松;向量 L2 距离,1.0 约等于余弦相似度 0.5。默认 1.0。
-            </FieldDescription>
-          </Field>
-        </FieldGroup>
-      </SectionCard>
-    </TabsContent>
+    </ConfigTabContent>
   )
 }

--- a/components/admin/config/storage-settings.tsx
+++ b/components/admin/config/storage-settings.tsx
@@ -1,18 +1,19 @@
 "use client"
 
-import { TabsContent } from "@/components/ui/tabs"
 import { Field, FieldGroup, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { SectionCard } from "@/components/admin/section-card"
+import { ConfigTabContent } from "./config-tab-content"
 
 import type { ConfigForm } from "./use-config-form"
 
 export function StorageSettings({
   cfg,
   updateField,
-}: Pick<ConfigForm, "cfg" | "updateField">) {
+  embedded = false,
+}: Pick<ConfigForm, "cfg" | "updateField"> & { embedded?: boolean }) {
   return (
-    <TabsContent value="storage">
+    <ConfigTabContent value="storage" embedded={embedded}>
       <SectionCard title="存储" description="数据库文件路径。">
         <FieldGroup>
           <Field>
@@ -26,6 +27,6 @@ export function StorageSettings({
           </Field>
         </FieldGroup>
       </SectionCard>
-    </TabsContent>
+    </ConfigTabContent>
   )
 }

--- a/components/admin/config/tg-settings.tsx
+++ b/components/admin/config/tg-settings.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { X, Plus } from "lucide-react"
-import { TabsContent } from "@/components/ui/tabs"
 import {
   Field,
   FieldDescription,
@@ -13,6 +12,7 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { SectionCard } from "@/components/admin/section-card"
 import { ChannelDot } from "@/components/channel-status-lights"
+import { ConfigTabContent } from "./config-tab-content"
 
 import type { ConfigForm } from "./use-config-form"
 
@@ -28,6 +28,7 @@ export function TgSettings({
   tgBypassWarn,
   tgChannel,
   tgChatTitle,
+  embedded = false,
 }: Pick<
   ConfigForm,
   | "cfg"
@@ -41,9 +42,9 @@ export function TgSettings({
   | "tgBypassWarn"
   | "tgChannel"
   | "tgChatTitle"
->) {
+> & { embedded?: boolean }) {
   return (
-    <TabsContent value="tg">
+    <ConfigTabContent value="tg" embedded={embedded}>
       <SectionCard
         title="TG 通道"
         description="Telegram Bot Token 与群相关参数。"
@@ -142,6 +143,6 @@ export function TgSettings({
           </Field>
         </FieldGroup>
       </SectionCard>
-    </TabsContent>
+    </ConfigTabContent>
   )
 }

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -15,6 +15,7 @@ function Tabs({
     <TabsPrimitive.Root
       data-slot="tabs"
       data-orientation={orientation}
+      orientation={orientation}
       className={cn(
         "group/tabs flex gap-2 data-horizontal:flex-col",
         className


### PR DESCRIPTION
## Summary
- 按用途将设置项归类为 5 个分类，并改为侧边导航
- 将知识库预检索独立到知识分类，复用统一内容容器
- 修复垂直 Tabs 的 orientation 传递，并补充设置分类无障碍标签

## Validation
- `pnpm check`
- `NEXT_DIST_DIR=.next-verify pnpm build`

## Notes
- 保留了工作区中既有的 `lib/agent/agent.ts` 未提交修改。