### PR TITLE
fix(ui): 移动端侧栏闪黑 + 点导航项自动关抽屉

### DIFF
--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -41,7 +41,8 @@ function SheetOverlay({
     <SheetPrimitive.Backdrop
       data-slot="sheet-overlay"
       className={cn(
-        "fixed inset-0 isolate z-50 bg-black/80 duration-100 data-ending-style:animate-out data-ending-style:fade-out-0 data-starting-style:animate-in data-starting-style:fade-in-0 supports-backdrop-filter:backdrop-blur-xs",
+        // fill-mode-forwards：遮罩退场(100ms)比面板(200ms)快，不保持终帧就会弹回全黑
+        "fixed inset-0 isolate z-50 bg-black/80 duration-100 data-ending-style:animate-out data-ending-style:fade-out-0 data-ending-style:fill-mode-forwards data-starting-style:animate-in data-starting-style:fade-in-0 supports-backdrop-filter:backdrop-blur-xs",
         className
       )}
       {...props}

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -199,7 +199,17 @@ function Sidebar({
             <SheetTitle>Sidebar</SheetTitle>
             <SheetDescription>Displays the mobile sidebar.</SheetDescription>
           </SheetHeader>
-          <div className="flex h-full w-full flex-col">{children}</div>
+          {/* 关抽屉靠事件委托:Link 的跳转在子元素先冒泡触发,此处再关不会打断它 */}
+          <div
+            className="flex h-full w-full flex-col"
+            onClick={(event) => {
+              if ((event.target as Element).closest("a[href]")) {
+                setOpenMobile(false)
+              }
+            }}
+          >
+            {children}
+          </div>
         </SheetContent>
       </Sheet>
     )

--- a/tests/ui/sheet-animation-contracts.test.ts
+++ b/tests/ui/sheet-animation-contracts.test.ts
@@ -1,0 +1,16 @@
+import { readFile } from "node:fs/promises"
+import { describe, expect, it } from "vitest"
+
+describe("Base UI sheet exit animation contract", () => {
+  // 移动端侧栏遮罩的退场动画必须保持终帧。
+  // 遮罩是 duration-100、面板是 duration-200;tw-animate-css 的 animate-out
+  // 默认 animation-fill-mode: none,动画一结束就回到基础样式(bg-black/80 即全黑),
+  // 于是面板还没退完的两百毫秒里整屏会闪成纯黑。
+  it("holds the backdrop's final frame through the popup exit animation", async () => {
+    const source = await readFile("components/ui/sheet.tsx", "utf8")
+    const overlayClass = source.match(/"[^"]*bg-black\/80[^"]*"/)?.[0]
+
+    expect(overlayClass).toBeDefined()
+    expect(overlayClass).toMatch(/data-ending-style:fill-mode-forwards/)
+  })
+})

--- a/tests/ui/sidebar-migration-contracts.test.ts
+++ b/tests/ui/sidebar-migration-contracts.test.ts
@@ -6,14 +6,21 @@ const app = readFileSync("components/app-sidebar.tsx", "utf8")
 
 describe("Base UI sidebar migration", () => {
   it("uses Base render primitives without Radix Slot/asChild", () => {
-    expect(sidebar).toContain('@base-ui/react/use-render')
-    expect(sidebar).toContain('@base-ui/react/merge-props')
+    expect(sidebar).toContain("@base-ui/react/use-render")
+    expect(sidebar).toContain("@base-ui/react/merge-props")
     expect(sidebar).not.toContain('from "radix-ui"')
     expect(sidebar).not.toMatch(/\basChild\b/)
   })
 
   it("uses render for the navigation link consumer", () => {
-    expect(app).toContain('render={<Link href={n.href} />}')
+    expect(app).toContain("render={<Link href={n.href} />}")
     expect(app).not.toContain("asChild")
+  })
+
+  it("closes the mobile drawer when a navigation link is clicked", () => {
+    // 事件委托在移动端 Sheet 的内容包裹层:点任意 a[href] 即关抽屉,
+    // 不必给每个菜单项各接一次 onClick;开启状态归 Sidebar 所有。
+    expect(sidebar).toMatch(/closest\("a\[href\]"\)/)
+    expect(sidebar).toContain("setOpenMobile(false)")
   })
 })


### PR DESCRIPTION
## 问题

移动端从侧栏菜单切换后，关闭抽屉时整屏会闪一下纯黑（实测约 100ms，肉眼“特别快”）。顺带发现点导航项后抽屉不会自动关闭，必须再点一次空白处。

## 根因（闪黑）

1. `SheetOverlay` 退场用 `duration-100`，`SheetContent` 面板是 `duration-200`（`components/ui/sheet.tsx`）。
2. `tw-animate-css` 的 `--animate-out` 默认 `animation-fill-mode: none`：

   ```css
   --animate-out: exit var(--tw-animation-duration, var(--tw-duration, .15s)) … var(--tw-animation-fill-mode, none);
   @keyframes exit { to { opacity: var(--tw-exit-opacity, 1); … } }
   ```

3. base-ui 在**面板**动画结束（200ms）才卸载门户。遮罩 100ms 就演完、且不保持终帧 → opacity 弹回基础值 1 → 全屏 `bg-black/80` 裸露约 100ms，而面板此时 opacity 已 ≈ 0。

`dialog.tsx` / `alert-dialog.tsx` 的遮罩与面板都是 `duration-100`，所以只有 sheet 命中。

## 改动

- **闪黑**：遮罩加 `data-ending-style:fill-mode-forwards`，令退场动画保持终帧。已核对生产构建产物：

  ```css
  .data-ending-style\:fill-mode-forwards[data-ending-style]{--tw-animation-fill-mode:forwards;animation-fill-mode:forwards}
  ```

- **自动关抽屉**：在移动端 Sheet 的内容包裹层做事件委托，命中 `a[href]` 就 `setOpenMobile(false)`。放在 `Sidebar` 而非 `AppSidebar`，抽屉开关状态不外泄给导航组件，也免去每个菜单项各接一次 `onClick`。

## 验证

390×844 视口 + CDP screencast 逐帧灰阶（真实绘制像素，非推测）：

- 闪黑修前：关闭抽屉 `246 → 79 → … → 49 → 246`，约 11 帧纯黑。
- 闪黑修后：`240 → 244 → 246` 单调变亮，最低 200（即正常遮罩），无黑帧。
- 打开路径本就无黑帧；真机触摸仿真与程序化点击均可复现与验证。
- 关抽屉不打断跳转：在现网构建上同 tick 触发 `link.click()` + `onOpenChange(false)`，URL 正常变更到目标页、抽屉关闭、遮罩移除。

合同测试：`tests/ui/sheet-animation-contracts.test.ts`、`tests/ui/sidebar-migration-contracts.test.ts`，均修前红、修后绿。

`pnpm check` 通过：typecheck 干净、960 tests 绿、lint 仅 1 条既有无关 warning（`tests/lib/ranking-route.test.ts:5`）。

## 未验证

“点导航项自动关抽屉”这条新逻辑本身没在**新构建**的运行时里跑过 —— 现网仍是旧构建，且本机有“多实例共写一库”的历史事故，不能另起实例。上面的等价验证覆盖的是同一关闭路径（`onOpenChange(false)`），新 handler 需部署后再确认真机表现。